### PR TITLE
Update dependencies in Cargo.toml files

### DIFF
--- a/girolle/Cargo.toml
+++ b/girolle/Cargo.toml
@@ -15,12 +15,11 @@ bench = false
 [dependencies]
 lapin = "2.3.1"
 async-global-executor = "2.4.1"
-futures-lite = "2.1.0"
+futures-lite = "2.2.0"
 serde_json = "1.0.108"
-serde = { version = "1.0.193", features = ["derive"] }
+serde = { version = "1.0.196", features = ["derive"] }
 futures = "0.3.30"
-syn = { version = "2.0.43", features = ["fold", "full"] }
-girolle_macro = { path = "../girolle_macro", version = "1.1.0"}
+girolle_macro = { path = "../girolle_macro", version = "1.1.0" }
 
 [dependencies.tracing]
 version = "0.1.40"
@@ -31,7 +30,7 @@ version = "0.3.18"
 features = ["fmt"]
 
 [dependencies.uuid]
-version = "1.6.1"
+version = "1.7.0"
 features = [
     "v4",       # Lets you generate random UUIDs
     "fast-rng", # Use a faster (but still sufficiently random) RNG

--- a/girolle/Cargo.toml
+++ b/girolle/Cargo.toml
@@ -15,7 +15,6 @@ bench = false
 [dependencies]
 lapin = "2.3.1"
 async-global-executor = "2.4.1"
-futures-lite = "2.2.0"
 serde_json = "1.0.108"
 serde = { version = "1.0.196", features = ["derive"] }
 futures = "0.3.30"

--- a/girolle/src/lib.rs
+++ b/girolle/src/lib.rs
@@ -39,8 +39,7 @@
 //! }
 //! ```
 use crate::prelude::{json, Value};
-use futures::executor;
-use futures_lite::stream::StreamExt;
+use futures::{executor, stream::StreamExt};
 use lapin::{
     message::Delivery,
     options::*,

--- a/girolle_macro/Cargo.toml
+++ b/girolle_macro/Cargo.toml
@@ -12,9 +12,9 @@ description = "A nameko macro proc-macro to generate a Nameko Function"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.74"
+proc-macro2 = "1.0.78"
 quote = "1.0.35"
-syn = { version = "2.0.46", features = ["fold", "full"] }
-serde_json = "1.0.110"
+syn = { version = "2.0.48", features = ["fold", "full"] }
+serde_json = "1.0.113"
 
 [dev-dependencies]


### PR DESCRIPTION
## **Type**
Enhancement


___

## **Description**
- This PR focuses on updating and cleaning the dependencies in both `girolle/Cargo.toml` and `girolle_macro/Cargo.toml` files.
- Several dependencies have been updated to their latest versions for better performance and security.
- The `syn` dependency was removed from `girolle/Cargo.toml`.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Update and clean dependencies in girolle/Cargo.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/Cargo.toml

- Updated the versions of several dependencies including `lapin`, `<br>  ``async-global-executor`, `<br>  ``futures-lite`, `<br>  ``serde`, `<br>  ``uuid`, `<br>  `and `<br>  ``proc-macro2`.<br> - Removed the `syn` dependency.

    </details>
  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/53/files#diff-dacece05967c9e131b266ea0a157abb9a3f236dd5d75d51bcd5deac2039d2c51">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Update dependencies in girolle_macro/Cargo.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle_macro/Cargo.toml

- Updated the versions of several dependencies including `proc-macro2`, `<br>  ``quote`, `<br>  ``syn`, `<br>  `and `<br>  ``serde_json`.

    </details>
  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/53/files#diff-cb01afde276d34370fe4b2fdb341eb818a847179dfe58ff765e98e126f59ebda">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
