### PR TITLE
Corriger les appels de fonction create_message_queue() pour utiliser …

### DIFF
--- a/girolle/src/lib.rs
+++ b/girolle/src/lib.rs
@@ -204,7 +204,7 @@ impl RpcClient {
             .with_headers(FieldTable::from(headers));
         let reply_name = "rpc.listener".to_string();
         let rpc_queue_reply = format!("{}-{}", reply_name, &self.identifier);
-        let reply_queue = create_message_queue(rpc_queue_reply.clone(), &self.identifier).await?;
+        let reply_queue = create_message_queue(&rpc_queue_reply, &self.identifier).await?;
         let consumer = reply_queue
             .basic_consume(
                 &rpc_queue_reply,
@@ -663,7 +663,7 @@ fn rpc_service(service_name: String, f: HashMap<String, NamekoFunction>) -> lapi
 
     async_global_executor::block_on(async {
         let rpc_queue_reply = format!("rpc.reply-{}-{}", service_name, &id);
-        let response_channel = create_message_queue(rpc_queue_reply.clone(), &id).await?;
+        let response_channel = create_message_queue(&rpc_queue_reply, &id).await?;
         let incomming_channel = create_service_queue(service_name).await?;
         // Start a consumer.
         let mut consumer = incomming_channel

--- a/girolle/src/queue.rs
+++ b/girolle/src/queue.rs
@@ -69,7 +69,7 @@ pub async fn create_service_queue(service_name: String) -> lapin::Result<lapin::
 /// * `rpc_queue_reply` - A string slice that holds the name of the queue.
 /// * `id` - A string slice that holds the id of the message.
 pub async fn create_message_queue(
-    rpc_queue_reply: String,
+    rpc_queue_reply: &str,
     id: &Uuid,
 ) -> lapin::Result<lapin::Channel> {
     const QUEUE_TTL: u32 = 300000;
@@ -80,11 +80,11 @@ pub async fn create_message_queue(
     let mut queue_declare_options = QueueDeclareOptions::default();
     queue_declare_options.durable = true;
     response_channel
-        .queue_declare(&rpc_queue_reply, queue_declare_options, response_arguments)
+        .queue_declare(rpc_queue_reply, queue_declare_options, response_arguments)
         .await?;
     response_channel
         .queue_bind(
-            &rpc_queue_reply,
+            rpc_queue_reply,
             "nameko-rpc",
             &id.to_string(),
             QueueBindOptions::default(),


### PR DESCRIPTION
## **User description**
…des références plutôt que des clones de chaînes de caractères.


___

## **Type**
enhancement


___

## **Description**
- Optimized `create_message_queue` function calls across the project to use string references instead of cloning strings, reducing memory usage.
- Updated `create_message_queue` function signature in `girolle/src/queue.rs` to accept a string slice, aligning with Rust's best practices for efficient string handling.
- Adjusted calls to `create_message_queue` in `girolle/src/lib.rs` to pass string references, eliminating unnecessary string clones.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Optimize `create_message_queue` Calls by Using References</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/lib.rs

<li>Modified <code>create_message_queue</code> calls to use references instead of <br>cloning strings.<br> <li> Adjusted the <code>basic_consume</code> method call to use the modified <br><code>create_message_queue</code> function signature.<br>


</details>

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/55/files#diff-df51b0b24fbb629077ebc369346fae19e9b27be8c799d416dfc3bb3e747d3cde">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>queue.rs</strong><dd><code>Refactor `create_message_queue` to Use String References</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/queue.rs

<li>Changed the <code>create_message_queue</code> function signature to accept a string <br>slice for the queue name instead of a owned string.<br> <li> Updated <code>queue_declare</code> and <code>queue_bind</code> calls within <code>create_message_queue</code> <br>to use the new parameter type.<br>


</details>

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/55/files#diff-5433fecc396195065e08ab0571749b5adbceea0364e4ee6358b3fc8a0b8d2c51">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
