### PR TITLE
Limit tokio thread

### DIFF
--- a/girolle/src/config.rs
+++ b/girolle/src/config.rs
@@ -86,7 +86,7 @@ impl Config {
                 map
             }),
             login_method: Some("".to_string()),
-            max_workers: Some(10),
+            max_workers: Some(256),
             prefetch_count: Some(10),
             parent_calls_tracked: Some(10),
             call_id_stack: Some("call_id_stack".to_string()),
@@ -207,6 +207,18 @@ impl Config {
     pub fn rpc_exchange(&self) -> &str {
         self.rpc_exchange.as_ref().unwrap()
     }
+    /// # max_workers
+    /// 
+    /// ## Description
+    /// 
+    /// Function to get the max workers.
+    /// 
+    /// ## Returns
+    /// 
+    /// A u32 that holds the max workers.
+    pub fn max_workers(&self) -> u32 {
+        self.max_workers.unwrap()
+    }
     /// # with_amqp_uri
     /// 
     /// ## Description
@@ -220,6 +232,7 @@ impl Config {
     /// ## Returns
     /// 
     /// A Config that holds the new configuration.
+    // Get the max workers
     pub fn with_amqp_uri(&self, amqp_uri: &str) -> Config {
         let mut new_config = self.clone();
         new_config.AMQP_URI = Some(amqp_uri.to_string());
@@ -277,6 +290,24 @@ impl Config {
     pub fn with_rpc_exchange(&self, rpc_exchange: &str) -> Config {
         let mut new_config = self.clone();
         new_config.rpc_exchange = Some(rpc_exchange.to_string());
+        new_config
+    }
+    /// # with_max_workers
+    /// 
+    /// ## Description
+    /// 
+    /// Function to set the max workers.
+    /// 
+    /// ## Arguments
+    /// 
+    /// * `max_workers` - A u32 that holds the max workers.
+    /// 
+    /// ## Returns
+    /// 
+    /// A Config that holds the new configuration.
+    pub fn with_max_workers(&self, max_workers: u32) -> Config {
+        let mut new_config = self.clone();
+        new_config.max_workers = Some(max_workers);
         new_config
     }
 }

--- a/girolle/src/lib.rs
+++ b/girolle/src/lib.rs
@@ -54,7 +54,11 @@ use lapin::{
 };
 pub use serde_json as JsonValue;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicU8, Ordering},
+    Arc,
+};
+use std::{thread, time};
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 mod nameko_utils;
@@ -849,6 +853,7 @@ async fn rpc_service(
             FieldTable::default(),
         )
         .await?;
+    let counter = Arc::new(AtomicU8::new(0));
     consumer.set_delegate(move |delivery: DeliveryResult| {
         let rpc_reply_channel_clone: Arc<Channel> = Arc::clone(&rpc_reply_channel);
         let f_task_clone: Arc<
@@ -857,18 +862,20 @@ async fn rpc_service(
         let rpc_queue_reply_clone: Arc<String> = Arc::clone(&rpc_queue_reply);
         let rpc_exchange_clone: Arc<String> = Arc::clone(&atomic_rpc_exchange);
         async move {
-            info!("will consume");
-            let delivery = match delivery {
-                // Carries the delivery alongside its channel
-                Ok(Some(delivery)) => delivery,
-                // The consumer got canceled
-                Ok(None) => return,
-                // Carries the error and is always followed by Ok(None)
-                Err(error) => {
-                    dbg!("Failed to consume queue message {}", error);
-                    return;
-                }
-            };
+            counter.fetch_add(1, Ordering::SeqCst);
+            if counter.load(Ordering::SeqCst). < 10 {
+                info!("will consume");
+                let delivery = match delivery {
+                    // Carries the delivery alongside its channel
+                    Ok(Some(delivery)) => delivery,
+                    // The consumer got canceled
+                    Ok(None) => return,
+                    // Carries the error and is always followed by Ok(None)
+                    Err(error) => {
+                        dbg!("Failed to consume queue message {}", error);
+                        return;
+                    }
+                };
 
             let opt_routing_key = delivery.routing_key.to_string();
             let fn_service: NamekoFunction = match f_task_clone.get(&opt_routing_key) {

--- a/girolle/src/lib.rs
+++ b/girolle/src/lib.rs
@@ -833,7 +833,7 @@ async fn rpc_service(
         &conf.rpc_exchange(),
     )
     .await?;
-    let rpc_queue_reply = format!("rpc.reply-{}-{}", service_name, &id);
+    let rpc_queue_reply: String = format!("rpc.reply-{}-{}", service_name, &id);
     // Start a consumer.
     let consumer = rpc_channel
         .basic_consume(

--- a/girolle/src/lib.rs
+++ b/girolle/src/lib.rs
@@ -853,7 +853,7 @@ async fn rpc_service(
         )
         .await?,
         f_task,
-        rpc_queue_reply: format!("rpc.reply-{}-{}", service_name, &id),
+        rpc_queue_reply: rpc_queue_reply,
         rpc_exchange: conf.rpc_exchange().to_string(),
         semaphore: Semaphore::new(conf.max_workers() as usize),
     });

--- a/girolle/src/lib.rs
+++ b/girolle/src/lib.rs
@@ -850,7 +850,7 @@ async fn rpc_service(
             FieldTable::default(),
         )
         .await?;
-    let semaphore = Arc::new(Semaphore::new(32));
+    let semaphore = Arc::new(Semaphore::new(conf.max_workers() as usize));
     consumer.set_delegate(move |delivery: DeliveryResult| {
         let rpc_reply_channel_clone: Arc<Channel> = Arc::clone(&rpc_reply_channel);
         let f_task_clone: Arc<


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Increased the default value of `max_workers` from 10 to 256 in the configuration.
- Added getter and setter methods for `max_workers` in the `Config` struct, along with corresponding documentation.
- Introduced a new `SharedData` struct to encapsulate shared resources such as `rpc_reply_channel`, `f_task`, `rpc_queue_reply`, `rpc_exchange`, and a `Semaphore`.
- Refactored the `rpc_service` function to use the `SharedData` struct, replacing multiple `Arc` instances with a single `Arc<SharedData>`.
- Implemented a `Semaphore` to limit the number of spawned threads based on the `max_workers` configuration value.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rs</strong><dd><code>Add getter and setter for max_workers and update default value.</code></dd></summary>
<hr>
      
girolle/src/config.rs

<li>Increased <code>max_workers</code> default value from 10 to 256.<br> <li> Added <code>max_workers</code> getter and setter methods.<br> <li> Updated documentation for new methods.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/75/files#diff-267236f6f094fb701ce45164eaffcc11ceda141e9282ccc29fb6c0df021dd8fa">+32/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Refactor rpc_service to use SharedData and limit threads.</code></dd></summary>
<hr>
      
girolle/src/lib.rs

<li>Introduced <code>SharedData</code> struct to encapsulate shared resources.<br> <li> Replaced individual <code>Arc</code> instances with a single <code>Arc<SharedData></code>.<br> <li> Added a <code>Semaphore</code> to limit the number of spawned threads.<br> <li> Updated <code>rpc_service</code> function to use <code>SharedData</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/75/files#diff-df51b0b24fbb629077ebc369346fae19e9b27be8c799d416dfc3bb3e747d3cde">+30/-26</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

