### PR TITLE
chore: Update girolle_macro version to 1.5 in Cargo.toml

### DIFF
--- a/girolle/Cargo.toml
+++ b/girolle/Cargo.toml
@@ -17,7 +17,7 @@ lapin = "2.3.4"
 serde_json = { workspace = true }
 serde = { version = "1.0.202", features = ["derive"] }
 futures = "0.3.30"
-girolle_macro = { path = "../girolle_macro" }
+girolle_macro = { path = "../girolle_macro", version = "1.5"}
 tokio = { workspace = true }
 tokio-executor-trait = "2.1.1"
 tokio-reactor-trait = "1.1.0"


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added version specification (`1.5`) for the `girolle_macro` dependency in `girolle/Cargo.toml`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Specify version for `girolle_macro` dependency in Cargo.toml</code></dd></summary>
<hr>
      
girolle/Cargo.toml

- Added version specification for `girolle_macro` dependency.



</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/89/files#diff-dacece05967c9e131b266ea0a157abb9a3f236dd5d75d51bcd5deac2039d2c51">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

