### PR TITLE
chore: Update actions/checkout to v4 in rust.yml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
   build_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: 🔨 Build
         run: cargo build
@@ -39,14 +39,14 @@ jobs:
   bench:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: ⏲️ Bench
         run: cargo bench
   dry_publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rs/toolchain@v1
       with:
           toolchain: stable
@@ -59,7 +59,7 @@ jobs:
     needs: [dry_publish,bench,build_test,build-doc-draft]
     if: github.event_name == 'release' && github.event.action == 'created'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions-rs/toolchain@v1
       with:
           toolchain: stable


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated the GitHub Actions workflow file (`rust.yml`) to use `actions/checkout` version 4 instead of version 3.
- This change affects multiple job steps including `build_test`, `bench`, `dry_publish`, and the release job.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rust.yml</strong><dd><code>Upgrade `actions/checkout` to v4 in GitHub Actions workflow</code></dd></summary>
<hr>
      
.github/workflows/rust.yml

<li>Updated <code>actions/checkout</code> from version 3 to version 4 in multiple job <br>steps.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/99/files#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792d">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

