### PR TITLE
feat: Add queue_declare options to create_message_channel

### DIFF
--- a/girolle/src/config/mod.rs
+++ b/girolle/src/config/mod.rs
@@ -232,10 +232,9 @@ impl Config {
     ///
     /// A Config that holds the new configuration.
     // Get the max workers
-    pub fn with_amqp_uri(&self, amqp_uri: &str) -> Config {
-        let mut new_config = self.clone();
-        new_config.AMQP_URI = Some(amqp_uri.to_string());
-        new_config
+    pub fn with_amqp_uri(mut self, amqp_uri: &str) -> Config {
+        self.AMQP_URI = Some(amqp_uri.to_string());
+        self
     }
     /// # with_prefetch_count
     ///
@@ -250,10 +249,9 @@ impl Config {
     /// ## Returns
     ///
     /// A Config that holds the new configuration.
-    pub fn with_prefetch_count(&self, prefetch_count: u16) -> Config {
-        let mut new_config = self.clone();
-        new_config.prefetch_count = Some(prefetch_count);
-        new_config
+    pub fn with_prefetch_count(mut self, prefetch_count: u16) -> Config {
+        self.prefetch_count = Some(prefetch_count);
+        self
     }
     /// # with_heartbeat
     ///
@@ -268,10 +266,9 @@ impl Config {
     /// ## Returns
     ///
     /// A Config that holds the new configuration.
-    pub fn with_heartbeat(&self, heartbeat: u16) -> Config {
-        let mut new_config = self.clone();
-        new_config.heartbeat = Some(heartbeat);
-        new_config
+    pub fn with_heartbeat(mut self, heartbeat: u16) -> Config {
+        self.heartbeat = Some(heartbeat);
+        self
     }
     /// # with_rpc_exchange
     ///
@@ -286,10 +283,9 @@ impl Config {
     /// ## Returns
     ///
     /// A Config that holds the new configuration.
-    pub fn with_rpc_exchange(&self, rpc_exchange: &str) -> Config {
-        let mut new_config = self.clone();
-        new_config.rpc_exchange = Some(rpc_exchange.to_string());
-        new_config
+    pub fn with_rpc_exchange(mut self, rpc_exchange: &str) -> Config {
+        self.rpc_exchange = Some(rpc_exchange.to_string());
+        self
     }
     /// # with_max_workers
     ///
@@ -304,10 +300,9 @@ impl Config {
     /// ## Returns
     ///
     /// A Config that holds the new configuration.
-    pub fn with_max_workers(&self, max_workers: u32) -> Config {
-        let mut new_config = self.clone();
-        new_config.max_workers = Some(max_workers);
-        new_config
+    pub fn with_max_workers(mut self, max_workers: u32) -> Config {
+        self.max_workers = Some(max_workers);
+        self
     }
 }
 

--- a/girolle/src/queue/mod.rs
+++ b/girolle/src/queue/mod.rs
@@ -108,6 +108,7 @@ pub async fn create_message_channel(
     response_arguments.insert("x-expires".into(), QUEUE_TTL.into());
     let mut queue_declare_options = QueueDeclareOptions::default();
     queue_declare_options.durable = true;
+    // Need to clone the response_arguments because the queue_declare function takes ownership of the FieldTable
     response_channel
         .queue_declare(
             rpc_queue_reply,

--- a/girolle_macro/src/entry.rs
+++ b/girolle_macro/src/entry.rs
@@ -83,10 +83,10 @@ impl Fold for Task {
 
 pub(crate) fn girolle_task(input: TokenStream) -> TokenStream {
     let item_fn = parse2::<ItemFn>(input).unwrap();
-    let name = &item_fn.sig.ident.clone();
+    let name = item_fn.sig.ident.clone();
     let mut task = Task::new(name.clone());
     task.args = item_fn.sig.inputs.iter().cloned().collect();
-    let new_item_fn = task.fold_item_fn(item_fn.clone());
+    let new_item_fn = task.fold_item_fn(item_fn);
     task.add_input_serialize();
     let args_str: Vec<String> = task
         .args


### PR DESCRIPTION
### **User description**
The `create_message_channel` function in `queue/mod.rs` now includes the `queue_declare_options` parameter, allowing for more flexibility in declaring queues. This change was made to support the upcoming feature of customizing queue properties during channel creation.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored `Config` methods to take ownership of `self` instead of borrowing, simplifying the method implementations by removing unnecessary cloning.
- Added comments in `create_message_channel` and `RpcService` methods to explain the need for cloning in various parts of the code.
- Changed function parameters in `RpcService` to take references where appropriate, and fixed potential issues with argument sizes in `build_inputs_fn_service`.
- Simplified the `girolle_task` function in `girolle_macro` by removing unnecessary clones.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Refactor Config methods to take ownership of self</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/config/mod.rs

<li>Changed methods to take ownership of <code>self</code> instead of borrowing.<br> <li> Simplified method implementations by removing unnecessary cloning.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/108/files#diff-7e45d463d466af8d4e5d02abc995ed7f40485bc0a4bd1a5b0aced1497ffd3563">+15/-20</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_service.rs</strong><dd><code>Add comments and refactor RpcService methods for clarity</code>&nbsp; </dd></summary>
<hr>
      
girolle/src/rpc_service.rs

<li>Added comments explaining the need for cloning in various parts of the <br>code.<br> <li> Changed function parameters to take references where appropriate.<br> <li> Fixed potential issues with argument sizes in <code>build_inputs_fn_service</code>.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/108/files#diff-905fc53bd11f000b1d04f3652165202c7e78c765664736b6908058150c364ed2">+21/-15</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>entry.rs</strong><dd><code>Simplify girolle_task function by removing unnecessary clones</code></dd></summary>
<hr>
      
girolle_macro/src/entry.rs

<li>Simplified the <code>girolle_task</code> function by removing unnecessary clones.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/108/files#diff-3f8670e79dfae2d4fcfd67e0170dd01db3bdfb2785f862ddb1cb2049c259beb9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add comment for cloning response_arguments in create_message_channel</code></dd></summary>
<hr>
      
girolle/src/queue/mod.rs

- Added a comment explaining the need to clone `response_arguments`.



</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/108/files#diff-0077581ee5d731afe306563568767b5fdbc4442867c3ff4208f57a0c5e2fbb33">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

