### PR TITLE
113 add a timestamp to the rpcreply and impl elapsed time

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,27 +147,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Send the payload
     let p = Payload::new().arg(30);
     let new_result = rpc_client.send(service_name, "fibonacci", p)?;
-    let fib_result: u64 = serde_json::from_value(new_result)?;
+    let fib_result: u64 = serde_json::from_value(new_result.get_value())?;
     // Print the result
     println!("fibonacci :{:?}", fib_result);
     assert_eq!(fib_result, 832040);
     let sub_result = rpc_client.send(service_name, "sub", Payload::new().arg(10).arg(5))?;
-    assert_eq!(sub_result, Value::Number(serde_json::Number::from(5)));
+    assert_eq!(sub_result.get_value(), Value::Number(serde_json::Number::from(5)));
     // Create a future result
     let future_result = rpc_client.call_async(service_name, "hello", Payload::new().arg("Toto"))?;
     // Send a message during the previous async process
     let result = rpc_client.send(service_name, "hello", Payload::new().arg("Girolle"))?;
     // Print the result
-    println!("{:?}", result);
-    assert_eq!(result, Value::String("Hello, Girolle!".to_string()));
+    println!("{:?}", result.get_value());
+    assert_eq!(result.get_value(), Value::String("Hello, Girolle!".to_string()));
     // wait for it
     let tempo: time::Duration = time::Duration::from_secs(4);
     thread::sleep(tempo);
     println!("exit sleep");
     // Print the result
-    let async_result = rpc_client.result(future_result)?;
-    println!("{:?}", async_result);
-    assert_eq!(async_result, Value::String("Hello, Toto!".to_string()));
+    let async_result = rpc_client.result(&future_result)?;
+    println!("{:?}", async_result.get_value());
+    assert_eq!(async_result.get_value(), Value::String("Hello, Toto!".to_string()));
+    println!("Time elapsed in for the previous call is: {:?}", async_result.get_elapsed_time()-tempo);
     let start = Instant::now();
     let mut consummers: Vec<_> = Vec::new();
     for n in 1..1001 {
@@ -179,7 +180,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // wait for it
     thread::sleep(tempo);
     for con in consummers {
-        let _async_result = rpc_client.result(con.1?)?;
+        let _async_result = rpc_client.result(&con.1?)?;
     }
     let duration = start.elapsed() - tempo;
     println!("Time elapsed in expensive_function() is: {:?}", duration);

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -7,7 +7,7 @@ title = "A nameko like lib in rust"
 lead = 'A nameko like lib in rust'
 url = "/docs/getting-started/introduction/"
 url_button = "Get started"
-repo_version = "GitHub v1.7.2"
+repo_version = "GitHub v1.8.0"
 repo_license = "Open-source MIT License."
 repo_url = "https://github.com/doubleailes/girolle"
 

--- a/examples/async_test.rs
+++ b/examples/async_test.rs
@@ -25,8 +25,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     thread::sleep(tempo);
     println!("exit sleep");
     for con in consummers {
-        let _async_result = rpc_client.result(con.1)?;
-        println!("{:?}", _async_result);
+        let _async_result = rpc_client.result(&con.1)?;
+        println!("{:?}", _async_result.get_result());
     }
     let duration = start.elapsed() - tempo;
     println!("Time elapsed in expensive_function() is: {:?}", duration);

--- a/examples/async_test.rs
+++ b/examples/async_test.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("exit sleep");
     for con in consummers {
         let _async_result = rpc_client.result(&con.1)?;
-        println!("{:?}", _async_result.get_result());
+        println!("{:?}", _async_result.get_value());
     }
     let duration = start.elapsed() - tempo;
     println!("Time elapsed in expensive_function() is: {:?}", duration);

--- a/examples/simple_sender.rs
+++ b/examples/simple_sender.rs
@@ -14,27 +14,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Send the payload
     let p = Payload::new().arg(30);
     let new_result = rpc_client.send(service_name, "fibonacci", p)?;
-    let fib_result: u64 = serde_json::from_value(new_result)?;
+    let fib_result: u64 = serde_json::from_value(new_result.get_result())?;
     // Print the result
     println!("fibonacci :{:?}", fib_result);
     assert_eq!(fib_result, 832040);
     let sub_result = rpc_client.send(service_name, "sub", Payload::new().arg(10).arg(5))?;
-    assert_eq!(sub_result, Value::Number(serde_json::Number::from(5)));
+    assert_eq!(sub_result.get_result(), Value::Number(serde_json::Number::from(5)));
     // Create a future result
     let future_result = rpc_client.call_async(service_name, "hello", Payload::new().arg("Toto"))?;
     // Send a message during the previous async process
     let result = rpc_client.send(service_name, "hello", Payload::new().arg("Girolle"))?;
     // Print the result
-    println!("{:?}", result);
-    assert_eq!(result, Value::String("Hello, Girolle!".to_string()));
+    println!("{:?}", result.get_result());
+    assert_eq!(result.get_result(), Value::String("Hello, Girolle!".to_string()));
     // wait for it
     let tempo: time::Duration = time::Duration::from_secs(4);
     thread::sleep(tempo);
     println!("exit sleep");
     // Print the result
-    let async_result = rpc_client.result(future_result)?;
-    println!("{:?}", async_result);
-    assert_eq!(async_result, Value::String("Hello, Toto!".to_string()));
+    let async_result = rpc_client.result(&future_result)?;
+    println!("{:?}", async_result.get_result());
+    assert_eq!(async_result.get_result(), Value::String("Hello, Toto!".to_string()));
+    println!("Time elapsed in for the previous call is: {:?}", async_result.get_elapsed_time()-tempo);
     let start = Instant::now();
     let mut consummers: Vec<_> = Vec::new();
     for n in 1..1001 {
@@ -46,7 +47,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // wait for it
     thread::sleep(tempo);
     for con in consummers {
-        let _async_result = rpc_client.result(con.1?)?;
+        let _async_result = rpc_client.result(&con.1?)?;
     }
     let duration = start.elapsed() - tempo;
     println!("Time elapsed in expensive_function() is: {:?}", duration);

--- a/examples/simple_sender.rs
+++ b/examples/simple_sender.rs
@@ -14,27 +14,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Send the payload
     let p = Payload::new().arg(30);
     let new_result = rpc_client.send(service_name, "fibonacci", p)?;
-    let fib_result: u64 = serde_json::from_value(new_result.get_result())?;
+    let fib_result: u64 = serde_json::from_value(new_result.get_value())?;
     // Print the result
     println!("fibonacci :{:?}", fib_result);
     assert_eq!(fib_result, 832040);
     let sub_result = rpc_client.send(service_name, "sub", Payload::new().arg(10).arg(5))?;
-    assert_eq!(sub_result.get_result(), Value::Number(serde_json::Number::from(5)));
+    assert_eq!(sub_result.get_value(), Value::Number(serde_json::Number::from(5)));
     // Create a future result
     let future_result = rpc_client.call_async(service_name, "hello", Payload::new().arg("Toto"))?;
     // Send a message during the previous async process
     let result = rpc_client.send(service_name, "hello", Payload::new().arg("Girolle"))?;
     // Print the result
-    println!("{:?}", result.get_result());
-    assert_eq!(result.get_result(), Value::String("Hello, Girolle!".to_string()));
+    println!("{:?}", result.get_value());
+    assert_eq!(result.get_value(), Value::String("Hello, Girolle!".to_string()));
     // wait for it
     let tempo: time::Duration = time::Duration::from_secs(4);
     thread::sleep(tempo);
     println!("exit sleep");
     // Print the result
     let async_result = rpc_client.result(&future_result)?;
-    println!("{:?}", async_result.get_result());
-    assert_eq!(async_result.get_result(), Value::String("Hello, Toto!".to_string()));
+    println!("{:?}", async_result.get_value());
+    assert_eq!(async_result.get_value(), Value::String("Hello, Toto!".to_string()));
     println!("Time elapsed in for the previous call is: {:?}", async_result.get_elapsed_time()-tempo);
     let start = Instant::now();
     let mut consummers: Vec<_> = Vec::new();

--- a/girolle/Cargo.toml
+++ b/girolle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "girolle"
-version = "1.7.2"
+version = "1.8.0"
 edition = "2021"
 authors = ["Philippe Llerena <philippe.llerena@gmail.com>"]
 description = "A nameko like lib in rust"

--- a/girolle/src/prelude.rs
+++ b/girolle/src/prelude.rs
@@ -1,7 +1,7 @@
 ///! This module contains the most commonly used types, functions and macros.
 pub use crate::config::Config;
 pub use crate::payload::Payload;
-pub use crate::rpc_client::RpcClient;
+pub use crate::rpc_client::{RpcClient,RpcReply,RpcResult};
 pub use crate::rpc_service::RpcService;
 pub use crate::rpc_task::RpcTask;
 pub use crate::types::{GirolleResult, NamekoFunction};

--- a/girolle/src/rpc_client.rs
+++ b/girolle/src/rpc_client.rs
@@ -567,7 +567,7 @@ impl RpcResult {
     /// ## Description
     /// 
     /// This function return the result of the RPC call as `serde_json::Value`
-    pub fn get_result(&self) -> Value {
+    pub fn get_value(&self) -> Value {
         self.result.clone()
     }
     /// # get_elapsed_time
@@ -592,17 +592,17 @@ mod tests {
         let elapsed_time = Duration::from_secs(5);
         let rpc_result = RpcResult::new(result.clone(), elapsed_time);
 
-        assert_eq!(rpc_result.get_result(), result);
+        assert_eq!(rpc_result.get_value(), result);
         assert_eq!(rpc_result.get_elapsed_time(), elapsed_time);
     }
 
     #[test]
-    fn test_rpc_result_get_result() {
+    fn test_rpc_result_get_value() {
         let result = json!({"success": true});
         let elapsed_time = Duration::from_secs(5);
         let rpc_result = RpcResult::new(result.clone(), elapsed_time);
 
-        assert_eq!(rpc_result.get_result(), result);
+        assert_eq!(rpc_result.get_value(), result);
     }
 
     #[test]

--- a/girolle/src/rpc_client.rs
+++ b/girolle/src/rpc_client.rs
@@ -2,6 +2,7 @@ use crate::config::Config;
 use crate::payload::Payload;
 use crate::queue::{create_message_channel, create_service_channel, get_connection};
 use crate::types::{GirolleError, GirolleResult};
+use std::time::{Duration, SystemTime,SystemTimeError};
 use futures::executor;
 use lapin::{
     message::DeliveryResult,
@@ -268,11 +269,17 @@ impl RpcClient {
     ///    let mut rpc_client = RpcClient::new(conf);
     ///    rpc_client.register_service("video").await.expect("call");
     ///    let method_name = "hello";
-    ///    let id = rpc_client.call_async("video", method_name, Payload::new().arg("John Doe"))?;
-    ///    let result = rpc_client.result(id)?;
+    ///    let rpc_event = rpc_client.call_async("video", method_name, Payload::new().arg("John Doe"))?;
+    ///    let result = rpc_client.result(&rpc_event)?;
     ///    Ok(())
     /// }
-    pub fn result(&self, rpc_event: RpcReply) -> GirolleResult<Value> {
+    pub fn result(&self, rpc_event: &RpcReply) -> GirolleResult<RpcResult> {
+        Ok(RpcResult::new(
+            self._result(rpc_event)?,
+            rpc_event.get_elapsed_time()?,
+        ))
+    }
+    fn _result(&self, rpc_event: &RpcReply) -> GirolleResult<Value> {
         let incomming_id = rpc_event.get_correlation_id();
         loop {
             let result = {
@@ -339,12 +346,18 @@ impl RpcClient {
         target_service: &str,
         method_name: &str,
         payload: Payload,
-    ) -> GirolleResult<Value> {
-        Ok(self.result(self.call_async(target_service, method_name, payload)?)?)
+    ) -> GirolleResult<RpcResult> {
+        let rpc_event = self.call_async(target_service, method_name, payload)?;
+        Ok(RpcResult::new(
+            self._result(&rpc_event)?,
+            rpc_event.get_elapsed_time()?,
+
+        ))
     }
     fn service_exist(&self, service_name: &str) -> bool {
         self.services.contains_key(service_name)
     }
+    
     /// # get_config
     ///
     /// ## Description
@@ -511,14 +524,118 @@ impl TargetService {
         self.channel.id()
     }
 }
+/// # RpcReply
+/// 
+/// ## Description
+/// 
+/// This struct is used to create a RPC reply. It contains the correlation_id and the time_stamp
 pub struct RpcReply {
-    pub correlation_id: uuid::Uuid,
+    correlation_id: uuid::Uuid,
+    time_stamp: SystemTime,
+
 }
 impl RpcReply {
     fn new(correlation_id: uuid::Uuid) -> Self {
-        Self { correlation_id }
+        Self { correlation_id, time_stamp: SystemTime::now()}
     }
-    fn get_correlation_id(&self) -> String {
+    pub fn get_correlation_id(&self) -> String {
         self.correlation_id.to_string()
+    }
+    pub fn get_elapsed_time(&self) -> Result<Duration, SystemTimeError> {
+        self.time_stamp.elapsed()
+    }
+}
+
+/// # RpcResult
+/// 
+/// ## Description
+/// 
+/// This struct is used to create a RPC result. It contains the result and the elapsed_time
+pub struct RpcResult {
+    result: Value,
+    elapsed_time: Duration,
+}
+impl RpcResult {
+    fn new(result: Value, elapsed_time: Duration) -> Self {
+        Self {
+            result,
+            elapsed_time,
+        }
+    }
+    /// # get_result
+    /// 
+    /// ## Description
+    /// 
+    /// This function return the result of the RPC call as `serde_json::Value`
+    pub fn get_result(&self) -> Value {
+        self.result.clone()
+    }
+    /// # get_elapsed_time
+    /// 
+    /// ## Description
+    /// 
+    /// This function return the elapsed time of the RPC call as `std::time::Duration`
+    pub fn get_elapsed_time(&self) -> Duration {
+        self.elapsed_time
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::time::Duration;
+    use uuid::Uuid;
+
+    #[test]
+    fn test_rpc_result_new() {
+        let result = json!({"success": true});
+        let elapsed_time = Duration::from_secs(5);
+        let rpc_result = RpcResult::new(result.clone(), elapsed_time);
+
+        assert_eq!(rpc_result.get_result(), result);
+        assert_eq!(rpc_result.get_elapsed_time(), elapsed_time);
+    }
+
+    #[test]
+    fn test_rpc_result_get_result() {
+        let result = json!({"success": true});
+        let elapsed_time = Duration::from_secs(5);
+        let rpc_result = RpcResult::new(result.clone(), elapsed_time);
+
+        assert_eq!(rpc_result.get_result(), result);
+    }
+
+    #[test]
+    fn test_rpc_result_get_elapsed_time() {
+        let result = json!({"success": true});
+        let elapsed_time = Duration::from_secs(5);
+        let rpc_result = RpcResult::new(result, elapsed_time);
+
+        assert_eq!(rpc_result.get_elapsed_time(), elapsed_time);
+    }
+    #[test]
+    fn test_rpc_reply_new() {
+        let correlation_id = Uuid::new_v4();
+        let rpc_reply = RpcReply::new(correlation_id);
+
+        assert_eq!(rpc_reply.get_correlation_id(), correlation_id.to_string());
+    }
+
+    #[test]
+    fn test_rpc_reply_get_correlation_id() {
+        let correlation_id = Uuid::new_v4();
+        let rpc_reply = RpcReply::new(correlation_id);
+
+        assert_eq!(rpc_reply.get_correlation_id(), correlation_id.to_string());
+    }
+
+    #[test]
+    fn test_rpc_reply_get_elapsed_time() {
+        let correlation_id = Uuid::new_v4();
+        let rpc_reply = RpcReply::new(correlation_id);
+
+        // We can't predict the exact elapsed time, but it should be a very small duration
+        let elapsed_time = rpc_reply.get_elapsed_time().unwrap();
+        assert!(elapsed_time < Duration::from_secs(1));
     }
 }

--- a/girolle/src/types/mod.rs
+++ b/girolle/src/types/mod.rs
@@ -23,6 +23,7 @@ pub enum GirolleError {
     ArgumentsError(String),
     RemoteError(String),
     ServiceMissingError(String),
+    SystemTimeError(std::time::SystemTimeError),
 }
 
 impl fmt::Display for GirolleError {
@@ -33,6 +34,7 @@ impl fmt::Display for GirolleError {
             GirolleError::ArgumentsError(e) => write!(f, "Arguments error: {}", e),
             GirolleError::RemoteError(e) => write!(f, "Remote error: {}", e),
             GirolleError::ServiceMissingError(e) => write!(f, "Service missing error: {}", e),
+            GirolleError::SystemTimeError(e) => write!(f, "System time error: {}", e),
         }
     }
 }
@@ -45,6 +47,7 @@ impl fmt::Debug for GirolleError {
             GirolleError::ArgumentsError(e) => write!(f, "Arguments error: {}", e),
             GirolleError::RemoteError(e) => write!(f, "Remote error: {:?}", e),
             GirolleError::ServiceMissingError(e) => write!(f, "Service missing error: {:?}", e),
+            GirolleError::SystemTimeError(e) => write!(f, "System time error: {:?}", e),
         }
     }
 }
@@ -59,6 +62,12 @@ impl From<lapin::Error> for GirolleError {
     fn from(error: lapin::Error) -> Self {
         GirolleError::LapinError(error)
     }
+}
+impl From<std::time::SystemTimeError> for GirolleError {
+    fn from(error: std::time::SystemTimeError) -> Self {
+        GirolleError::SystemTimeError(error)
+    }
+    
 }
 
 impl std::error::Error for GirolleError {}

--- a/girolle_macro/Cargo.toml
+++ b/girolle_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "girolle_macro"
-version = "1.7.2"
+version = "1.8.0"
 edition = "2021"
 readme = "../README.md"
 license-file = "../LICENSE"


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Refactored RPC client payload handling in examples to use `get_value()` method for better readability and maintainability.
- Added `RpcReply` struct with timestamp and `RpcResult` struct with result and elapsed time.
- Updated `result` method to return `RpcResult` and added unit tests for `RpcReply` and `RpcResult`.
- Added `SystemTimeError` variant to `GirolleError` and implemented `From` trait for `SystemTimeError`.
- Updated README examples to use `get_value()` method and added elapsed time logging for async results.
- Updated repository and package versions to 1.8.0.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>async_test.rs</strong><dd><code>Refactor RPC client payload handling in async_test example</code></dd></summary>
<hr>
      
examples/async_test.rs

<li>Refactored to use <code>get_value()</code> method for better readability.<br> <li> Updated <code>result</code> method calls to pass references.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/117/files#diff-5be59fd8a48e0d69142850ee9b31acc0b9d7ab580da87f8a3a5d49e7aa6164ef">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>simple_sender.rs</strong><dd><code>Refactor RPC client payload handling in simple_sender example</code></dd></summary>
<hr>
      
examples/simple_sender.rs

<li>Refactored to use <code>get_value()</code> method for better readability.<br> <li> Updated <code>result</code> method calls to pass references.<br> <li> Added elapsed time logging for async results.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/117/files#diff-06d62d03dd0ff3cc6b743299af8917c4529585dfd695f7892a78e3938e0baf5f">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>prelude.rs</strong><dd><code>Export RpcReply and RpcResult in prelude</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/prelude.rs

- Added `RpcReply` and `RpcResult` to prelude exports.



</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/117/files#diff-4596cac6f7b5ee44fff37db2460827f9daa07e422d7002a7f380404e1c40460d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_client.rs</strong><dd><code>Add RpcReply and RpcResult structs with timestamp and elapsed time</code></dd></summary>
<hr>
      
girolle/src/rpc_client.rs

<li>Added <code>RpcReply</code> struct with timestamp.<br> <li> Added <code>RpcResult</code> struct with result and elapsed time.<br> <li> Refactored <code>result</code> method to return <code>RpcResult</code>.<br> <li> Added unit tests for <code>RpcReply</code> and <code>RpcResult</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/117/files#diff-a9fe91e540be452dba08af8646f6d3ab4453ab253a7791cb7db45bbdf0729aa9">+125/-8</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add SystemTimeError variant to GirolleError</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/types/mod.rs

<li>Added <code>SystemTimeError</code> variant to <code>GirolleError</code>.<br> <li> Implemented <code>From</code> trait for <code>SystemTimeError</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/117/files#diff-7093d4995ff475654107769e9dde05c11ce49cb339adfd46bb0b7d4dad75e1c0">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation
</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README examples with get_value method and elapsed time logging</code></dd></summary>
<hr>
      
README.md

<li>Updated example code to use <code>get_value()</code> method.<br> <li> Added elapsed time logging for async results.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/117/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>_index.md</strong><dd><code>Update repository version in documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
docs/content/_index.md

- Updated repository version to 1.8.0.



</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/117/files#diff-5d9ba8bc1a568741b44ccc852748ca739d71f89dc1ac05a9f8d3787a064a549d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Dependencies
</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump version to 1.8.0 in girolle/Cargo.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/Cargo.toml

- Updated package version to 1.8.0.



</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/117/files#diff-dacece05967c9e131b266ea0a157abb9a3f236dd5d75d51bcd5deac2039d2c51">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Bump version to 1.8.0 in girolle_macro/Cargo.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle_macro/Cargo.toml

- Updated package version to 1.8.0.



</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/117/files#diff-cb01afde276d34370fe4b2fdb341eb818a847179dfe58ff765e98e126f59ebda">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

