### PR TITLE
112 create a specific error encapsulate the remote error

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -31,3 +31,7 @@ path = "simple_macro.rs"
 [[example]]
 name = "async_test"
 path = "async_test.rs"
+
+[[example]]
+name = "error_sender"
+path = "error_sender.rs"

--- a/examples/error_sender.rs
+++ b/examples/error_sender.rs
@@ -23,6 +23,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         sub_result.get_value(),
         Value::Number(serde_json::Number::from(5))
     );
+    match rpc_client.send(service_name, "sub", Payload::new().arg(10).arg(5).arg(6)) {
+        Ok(_) => panic!("Should have failed"),
+        Err(e) => {
+            println!("{:?}", e);
+        }
+    }
     // Create a future result
     let future_result = rpc_client.call_async(service_name, "hello", Payload::new().arg("Toto"))?;
     // Send a message during the previous async process

--- a/examples/simple_sender.rs
+++ b/examples/simple_sender.rs
@@ -20,6 +20,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(fib_result, 832040);
     let sub_result = rpc_client.send(service_name, "sub", Payload::new().arg(10).arg(5))?;
     assert_eq!(sub_result.get_value(), Value::Number(serde_json::Number::from(5)));
+    match rpc_client.send(service_name, "sub", Payload::new().arg(10).arg(5).arg(6)) {
+        Ok(_) => panic!("Should have failed"),
+        Err(e )=> {
+            println!("{:?}", e);
+        }
+    }
     // Create a future result
     let future_result = rpc_client.call_async(service_name, "hello", Payload::new().arg("Toto"))?;
     // Send a message during the previous async process

--- a/examples/simple_sender.rs
+++ b/examples/simple_sender.rs
@@ -19,10 +19,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("fibonacci :{:?}", fib_result);
     assert_eq!(fib_result, 832040);
     let sub_result = rpc_client.send(service_name, "sub", Payload::new().arg(10).arg(5))?;
-    assert_eq!(sub_result.get_value(), Value::Number(serde_json::Number::from(5)));
+    assert_eq!(
+        sub_result.get_value(),
+        Value::Number(serde_json::Number::from(5))
+    );
     match rpc_client.send(service_name, "sub", Payload::new().arg(10).arg(5).arg(6)) {
         Ok(_) => panic!("Should have failed"),
-        Err(e )=> {
+        Err(e) => {
             println!("{:?}", e);
         }
     }
@@ -32,7 +35,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let result = rpc_client.send(service_name, "hello", Payload::new().arg("Girolle"))?;
     // Print the result
     println!("{:?}", result.get_value());
-    assert_eq!(result.get_value(), Value::String("Hello, Girolle!".to_string()));
+    assert_eq!(
+        result.get_value(),
+        Value::String("Hello, Girolle!".to_string())
+    );
     // wait for it
     let tempo: time::Duration = time::Duration::from_secs(4);
     thread::sleep(tempo);
@@ -40,8 +46,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Print the result
     let async_result = rpc_client.result(&future_result)?;
     println!("{:?}", async_result.get_value());
-    assert_eq!(async_result.get_value(), Value::String("Hello, Toto!".to_string()));
-    println!("Time elapsed in for the previous call is: {:?}", async_result.get_elapsed_time()-tempo);
+    assert_eq!(
+        async_result.get_value(),
+        Value::String("Hello, Toto!".to_string())
+    );
+    println!(
+        "Time elapsed in for the previous call is: {:?}",
+        async_result.get_elapsed_time() - tempo
+    );
     let start = Instant::now();
     let mut consummers: Vec<_> = Vec::new();
     for n in 1..1001 {

--- a/girolle/src/error/mod.rs
+++ b/girolle/src/error/mod.rs
@@ -1,6 +1,6 @@
-use std::fmt;
-use serde::{Deserialize,Serialize};
 use lapin;
+use serde::{Deserialize, Serialize};
+use std::fmt;
 
 pub enum GirolleError {
     SerdeJsonError(serde_json::Error),
@@ -61,48 +61,47 @@ impl From<std::time::SystemTimeError> for GirolleError {
     fn from(error: std::time::SystemTimeError) -> Self {
         GirolleError::SystemTimeError(error)
     }
-    
 }
 impl From<RemoteError> for GirolleError {
     fn from(error: RemoteError) -> Self {
         GirolleError::RemoteError(error)
     }
 }
-impl GirolleError{
-    pub fn convert(&self)->RemoteError {
+impl GirolleError {
+    pub fn convert(&self) -> RemoteError {
         match self {
             GirolleError::RemoteError(e) => e.clone(),
             GirolleError::IncorrectSignature(e) => RemoteError {
                 exc_path: "nameko.exceptions.IncorrectSignature".to_string(),
                 exc_type: "IncorrectSignature".to_string(),
                 value: e.clone(),
-                exc_args: vec![e.clone()]
+                exc_args: vec![e.clone()],
             },
             GirolleError::MethodNotFound(e) => RemoteError {
                 exc_path: "nameko.exceptions.MethodNotFound".to_string(),
                 exc_type: "MethodNotFound".to_string(),
                 value: e.clone(),
-                exc_args: vec![e.clone()]
+                exc_args: vec![e.clone()],
             },
             GirolleError::UnknownService(e) => RemoteError {
                 exc_path: "nameko.exceptions.UnknownService".to_string(),
                 exc_type: "UnknownService".to_string(),
                 value: e.clone(),
-                exc_args: vec![e.clone()]
+                exc_args: vec![e.clone()],
             },
             _ => RemoteError {
                 exc_path: "".to_string(),
                 exc_type: "".to_string(),
                 value: "".to_string(),
-                exc_args: vec![]
-            }
+                exc_args: vec![],
+            },
         }
     }
 }
 
 impl std::error::Error for GirolleError {}
 
-#[derive(Debug,Deserialize,Serialize,Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RemoteError {
     exc_path: String,
     exc_type: String,
@@ -110,20 +109,12 @@ pub struct RemoteError {
     exc_args: Vec<String>,
 }
 impl RemoteError {
-    pub fn convert_to_girolle_error(&self)-> GirolleError {
+    pub fn convert_to_girolle_error(&self) -> GirolleError {
         match self.exc_type.as_str() {
-            "IncorrectSignature" => {
-                GirolleError::IncorrectSignature(self.value.clone())
-            },
-            "MethodNotFound" => {
-                GirolleError::MethodNotFound(self.value.clone())
-            },
-            "UnknownService" => {
-                GirolleError::UnknownService(self.value.clone())
-            },
-            _ => {
-                GirolleError::RemoteError(self.clone())
-            }
+            "IncorrectSignature" => GirolleError::IncorrectSignature(self.value.clone()),
+            "MethodNotFound" => GirolleError::MethodNotFound(self.value.clone()),
+            "UnknownService" => GirolleError::UnknownService(self.value.clone()),
+            _ => GirolleError::RemoteError(self.clone()),
         }
     }
 }

--- a/girolle/src/error/mod.rs
+++ b/girolle/src/error/mod.rs
@@ -71,7 +71,7 @@ impl From<RemoteError> for GirolleError {
     }
 }
 impl GirolleError {
-    pub fn convert(&self) -> RemoteError {
+    pub(crate) fn convert(&self) -> RemoteError {
         match self {
             GirolleError::RemoteError(e) => e.clone(),
             GirolleError::IncorrectSignature(e) => RemoteError {
@@ -112,7 +112,7 @@ pub struct RemoteError {
     exc_args: Vec<String>,
 }
 impl RemoteError {
-    pub fn convert_to_girolle_error(&self) -> GirolleError {
+    pub(crate) fn convert_to_girolle_error(&self) -> GirolleError {
         match self.exc_type.as_str() {
             "IncorrectSignature" => GirolleError::IncorrectSignature(self.value.clone()),
             "MethodNotFound" => GirolleError::MethodNotFound(self.value.clone()),

--- a/girolle/src/error/mod.rs
+++ b/girolle/src/error/mod.rs
@@ -12,6 +12,7 @@ pub enum GirolleError {
     RemoteError(RemoteError),
     ServiceMissingError(String),
     SystemTimeError(std::time::SystemTimeError),
+    MissingHeader,
 }
 
 impl fmt::Display for GirolleError {
@@ -26,6 +27,7 @@ impl fmt::Display for GirolleError {
             GirolleError::ServiceMissingError(e) => write!(f, "Service missing error: {}", e),
             GirolleError::SystemTimeError(e) => write!(f, "System time error: {}", e),
             GirolleError::RemoteError(e) => write!(f, "Remote error: {:?}", e),
+            GirolleError::MissingHeader => write!(f, "Missing header"),
         }
     }
 }
@@ -42,6 +44,7 @@ impl fmt::Debug for GirolleError {
             GirolleError::ServiceMissingError(e) => write!(f, "Service missing error: {:?}", e),
             GirolleError::SystemTimeError(e) => write!(f, "System time error: {:?}", e),
             GirolleError::RemoteError(e) => write!(f, "Remote error: {:?}", e),
+            GirolleError::MissingHeader => write!(f, "Missing header"),
         }
     }
 }

--- a/girolle/src/error/mod.rs
+++ b/girolle/src/error/mod.rs
@@ -1,0 +1,129 @@
+use std::fmt;
+use serde::{Deserialize,Serialize};
+use lapin;
+
+pub enum GirolleError {
+    SerdeJsonError(serde_json::Error),
+    LapinError(lapin::Error),
+    ArgumentsError(String),
+    IncorrectSignature(String),
+    MethodNotFound(String),
+    UnknownService(String),
+    RemoteError(RemoteError),
+    ServiceMissingError(String),
+    SystemTimeError(std::time::SystemTimeError),
+}
+
+impl fmt::Display for GirolleError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            GirolleError::SerdeJsonError(e) => write!(f, "Serde JSON error: {}", e),
+            GirolleError::LapinError(e) => write!(f, "Lapin error: {}", e),
+            GirolleError::ArgumentsError(e) => write!(f, "Arguments error: {}", e),
+            GirolleError::IncorrectSignature(e) => write!(f, "Incorrect signature: {}", e),
+            GirolleError::MethodNotFound(e) => write!(f, "Method not found: {}", e),
+            GirolleError::UnknownService(e) => write!(f, "Unknown service: {}", e),
+            GirolleError::ServiceMissingError(e) => write!(f, "Service missing error: {}", e),
+            GirolleError::SystemTimeError(e) => write!(f, "System time error: {}", e),
+            GirolleError::RemoteError(e) => write!(f, "Remote error: {:?}", e),
+        }
+    }
+}
+
+impl fmt::Debug for GirolleError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            GirolleError::SerdeJsonError(e) => write!(f, "Serde JSON error: {:?}", e),
+            GirolleError::LapinError(e) => write!(f, "Lapin error: {:?}", e),
+            GirolleError::ArgumentsError(e) => write!(f, "Arguments error: {}", e),
+            GirolleError::IncorrectSignature(e) => write!(f, "Incorrect signature: {}", e),
+            GirolleError::MethodNotFound(e) => write!(f, "Method not found: {}", e),
+            GirolleError::UnknownService(e) => write!(f, "Unknown service: {}", e),
+            GirolleError::ServiceMissingError(e) => write!(f, "Service missing error: {:?}", e),
+            GirolleError::SystemTimeError(e) => write!(f, "System time error: {:?}", e),
+            GirolleError::RemoteError(e) => write!(f, "Remote error: {:?}", e),
+        }
+    }
+}
+
+impl From<serde_json::Error> for GirolleError {
+    fn from(error: serde_json::Error) -> Self {
+        GirolleError::SerdeJsonError(error)
+    }
+}
+
+impl From<lapin::Error> for GirolleError {
+    fn from(error: lapin::Error) -> Self {
+        GirolleError::LapinError(error)
+    }
+}
+impl From<std::time::SystemTimeError> for GirolleError {
+    fn from(error: std::time::SystemTimeError) -> Self {
+        GirolleError::SystemTimeError(error)
+    }
+    
+}
+impl From<RemoteError> for GirolleError {
+    fn from(error: RemoteError) -> Self {
+        GirolleError::RemoteError(error)
+    }
+}
+impl GirolleError{
+    pub fn convert(&self)->RemoteError {
+        match self {
+            GirolleError::RemoteError(e) => e.clone(),
+            GirolleError::IncorrectSignature(e) => RemoteError {
+                exc_path: "nameko.exceptions.IncorrectSignature".to_string(),
+                exc_type: "IncorrectSignature".to_string(),
+                value: e.clone(),
+                exc_args: vec![e.clone()]
+            },
+            GirolleError::MethodNotFound(e) => RemoteError {
+                exc_path: "nameko.exceptions.MethodNotFound".to_string(),
+                exc_type: "MethodNotFound".to_string(),
+                value: e.clone(),
+                exc_args: vec![e.clone()]
+            },
+            GirolleError::UnknownService(e) => RemoteError {
+                exc_path: "nameko.exceptions.UnknownService".to_string(),
+                exc_type: "UnknownService".to_string(),
+                value: e.clone(),
+                exc_args: vec![e.clone()]
+            },
+            _ => RemoteError {
+                exc_path: "".to_string(),
+                exc_type: "".to_string(),
+                value: "".to_string(),
+                exc_args: vec![]
+            }
+        }
+    }
+}
+
+impl std::error::Error for GirolleError {}
+
+#[derive(Debug,Deserialize,Serialize,Clone)]
+pub struct RemoteError {
+    exc_path: String,
+    exc_type: String,
+    value: String,
+    exc_args: Vec<String>,
+}
+impl RemoteError {
+    pub fn convert_to_girolle_error(&self)-> GirolleError {
+        match self.exc_type.as_str() {
+            "IncorrectSignature" => {
+                GirolleError::IncorrectSignature(self.value.clone())
+            },
+            "MethodNotFound" => {
+                GirolleError::MethodNotFound(self.value.clone())
+            },
+            "UnknownService" => {
+                GirolleError::UnknownService(self.value.clone())
+            },
+            _ => {
+                GirolleError::RemoteError(self.clone())
+            }
+        }
+    }
+}

--- a/girolle/src/lib.rs
+++ b/girolle/src/lib.rs
@@ -62,3 +62,5 @@ mod payload;
 pub use payload::Payload;
 pub use serde_json;
 pub use serde_json::{json, Value};
+mod error;
+pub use error::GirolleError;

--- a/girolle/src/nameko_utils/mod.rs
+++ b/girolle/src/nameko_utils/mod.rs
@@ -1,9 +1,15 @@
-use crate::error::GirolleError;
+use crate::error::{GirolleError, RemoteError};
+use crate::rpc_task::RpcTask;
+use lapin::options::BasicPublishOptions;
 /// # nameko_utils
 ///
 /// This module contains functions to manipulate the headers of the AMQP messages.
 use lapin::types::{AMQPValue, FieldTable, LongString, ShortString};
+use lapin::Channel;
 use lapin::{message::Delivery, BasicProperties};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::collections::HashMap;
 use tracing::error;
 use uuid::Uuid;
 
@@ -26,7 +32,7 @@ fn test_set_current_call_id() {
     );
 }
 
-pub fn insert_new_id_to_call_id(
+pub(crate) fn insert_new_id_to_call_id(
     mut headers: FieldTable,
     function_name: &str,
     id: &str,
@@ -45,7 +51,7 @@ pub fn insert_new_id_to_call_id(
     headers
 }
 
-pub fn get_id(opt_id: &Option<ShortString>, id_name: &str) -> String {
+pub(crate) fn get_id(opt_id: &Option<ShortString>, id_name: &str) -> String {
     match opt_id {
         Some(id) => id.to_string(),
         None => {
@@ -60,7 +66,7 @@ fn test_get_id() {
     assert_eq!(id, "id".to_string());
 }
 
-pub fn delivery_to_message_properties(
+pub(crate) fn delivery_to_message_properties(
     delivery: &Delivery,
     id: &Uuid,
     rpc_queue: &str,
@@ -85,4 +91,183 @@ pub fn delivery_to_message_properties(
         .with_headers(headers)
         .with_delivery_mode(2)
         .with_priority(0))
+}
+
+pub(crate) async fn publish(
+    rpc_channel: &Channel,
+    payload: String,
+    properties: BasicProperties,
+    reply_to_id: String,
+    rpc_exchange: &str,
+) -> lapin::Result<()> {
+    // Need to clone the rpc_channel to be able to use it in the tokio::spawn
+    let rpc_channel_clone = rpc_channel.clone();
+    let rpc_exchange_clone = rpc_exchange.to_string();
+    tokio::spawn(async move {
+        rpc_channel_clone
+            .basic_publish(
+                &rpc_exchange_clone,
+                &format!("{}", &reply_to_id),
+                BasicPublishOptions::default(),
+                payload.as_bytes(),
+                properties,
+            )
+            .await
+            .unwrap()
+            .await
+            .unwrap();
+    });
+    // The message was correctly published
+    Ok(())
+}
+
+fn push_values_to_result(
+    service_args: &[&str],
+    kwargs: &HashMap<String, Value>,
+    start: usize,
+    end: usize,
+) -> Result<Vec<Value>, GirolleError> {
+    let mut result: Vec<Value> = Vec::new();
+    let error_message = "Key is missing in kwargs".to_string();
+    for i in start..end {
+        result.push(
+            kwargs
+                .get(service_args[i])
+                .ok_or_else(|| GirolleError::IncorrectSignature(error_message.clone()))?
+                .clone(),
+        );
+    }
+    Ok(result)
+}
+
+fn build_inputs_fn_service(
+    service_args: &Vec<&str>,
+    data_delivery: DeliveryData,
+) -> Result<Vec<Value>, GirolleError> {
+    let args_size: usize = data_delivery.args.len();
+    let kwargs_size: usize = data_delivery.kwargs.len();
+    let service_args_size: usize = service_args.len();
+
+    match (
+        data_delivery.kwargs.is_empty(),
+        data_delivery.args.is_empty(),
+        service_args_size == args_size + kwargs_size,
+    ) {
+        (true, _, _) if service_args_size == args_size => Ok(data_delivery.args),
+        (_, true, _) if service_args_size == kwargs_size => {
+            push_values_to_result(service_args, &data_delivery.kwargs, 0, kwargs_size)
+        }
+        (_, _, true) => {
+            let mut result = data_delivery.args;
+            result.extend(push_values_to_result(
+                service_args,
+                &data_delivery.kwargs,
+                args_size,
+                args_size + kwargs_size,
+            )?);
+            Ok(result)
+        }
+        _ => Err(GirolleError::IncorrectSignature(format!(
+            "takes {} positional arguments but {} were given",
+            service_args_size,
+            args_size + kwargs_size
+        ))),
+    }
+}
+
+#[test]
+fn test_build_inputs_fn_service() {
+    let service_args = vec!["a", "b", "c"];
+    let data_delivery = DeliveryData {
+        args: vec![
+            Value::String("1".to_string()),
+            Value::String("2".to_string()),
+        ],
+        kwargs: HashMap::from([("c".to_string(), Value::String("3".to_string()))]),
+    };
+    let result = build_inputs_fn_service(&service_args, data_delivery);
+    assert_eq!(result.is_ok(), true);
+    let result = result.unwrap();
+    assert_eq!(result.len(), 3);
+    assert_eq!(result[0], Value::String("1".to_string()));
+    assert_eq!(result[1], Value::String("2".to_string()));
+    assert_eq!(result[2], Value::String("3".to_string()));
+}
+
+fn get_result_paylaod(result: Value) -> String {
+    json!(
+        {
+            "result": result,
+            "error": null,
+        }
+    )
+    .to_string()
+}
+
+pub(crate) fn get_error_payload(error: RemoteError) -> String {
+    json!(
+        {
+            "result": null,
+            "error": error,
+        }
+    )
+    .to_string()
+}
+#[derive(Debug, Deserialize)]
+pub struct DeliveryData {
+    args: Vec<Value>,
+    kwargs: HashMap<String, Value>,
+}
+/// Execute the delivery
+pub(crate) async fn compute_deliver(
+    incomming_data: DeliveryData,
+    properties: BasicProperties,
+    rpc_task_struct: &RpcTask,
+    rpc_channel: &Channel,
+    rpc_exchange: &str,
+    reply_to_id: String,
+) {
+    // Publish the response
+    let fn_service = rpc_task_struct.inner_function;
+    let buildted_args = match build_inputs_fn_service(&rpc_task_struct.args, incomming_data) {
+        Ok(result) => result,
+        Err(error) => {
+            publish(
+                &rpc_channel,
+                get_error_payload(error.convert()),
+                properties,
+                reply_to_id,
+                rpc_exchange,
+            )
+            .await
+            .expect("Error publishing");
+            return;
+        }
+    };
+    match fn_service(&buildted_args) {
+        Ok(result) => {
+            publish(
+                &rpc_channel,
+                get_result_paylaod(result),
+                properties,
+                reply_to_id,
+                rpc_exchange,
+            )
+            .await
+            .expect("Error publishing");
+            return;
+        }
+        Err(error) => {
+            publish(
+                &rpc_channel,
+                get_error_payload(error.convert()),
+                properties,
+                reply_to_id,
+                rpc_exchange,
+            )
+            .await
+            .expect("Error publishing");
+            return;
+        }
+    };
 }

--- a/girolle/src/payload/mod.rs
+++ b/girolle/src/payload/mod.rs
@@ -80,7 +80,8 @@ impl Payload {
     /// let p = Payload::new().arg(1);
     /// ```
     pub fn arg<T: Serialize>(mut self, arg: T) -> Self {
-        self.args.push(serde_json::to_value(arg).expect("Failed to serialize argument"));
+        self.args
+            .push(serde_json::to_value(arg).expect("Failed to serialize argument"));
         self
     }
     /// # kwarg
@@ -96,21 +97,23 @@ impl Payload {
     /// let p = Payload::new().kwarg("key", 1);
     /// ```
     pub fn kwarg<T: Serialize>(mut self, key: &str, value: T) -> Self {
-        self.kwargs
-            .insert(key.to_string(), serde_json::to_value(value).expect("Failed to serialize argument"));
+        self.kwargs.insert(
+            key.to_string(),
+            serde_json::to_value(value).expect("Failed to serialize argument"),
+        );
         self
     }
     pub fn to_string(&self) -> String {
         serde_json::to_string(self).unwrap()
     }
     /// # is_empty
-    /// 
+    ///
     /// ## Description
-    /// 
+    ///
     /// Check if the Payload is empty
-    /// 
+    ///
     /// ## Example
-    /// 
+    ///
     /// ```rust
     /// use girolle::prelude::Payload;
     /// let p = Payload::new();

--- a/girolle/src/prelude.rs
+++ b/girolle/src/prelude.rs
@@ -1,7 +1,7 @@
 ///! This module contains the most commonly used types, functions and macros.
 pub use crate::config::Config;
 pub use crate::payload::Payload;
-pub use crate::rpc_client::{RpcClient,RpcReply,RpcResult};
+pub use crate::rpc_client::{RpcClient, RpcReply, RpcResult};
 pub use crate::rpc_service::RpcService;
 pub use crate::rpc_task::RpcTask;
 pub use crate::types::{GirolleResult, NamekoFunction};

--- a/girolle/src/queue/mod.rs
+++ b/girolle/src/queue/mod.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 /// # QUEUE_TTL
 const QUEUE_TTL: u32 = 300000;
 
-pub async fn get_connection(
+pub(crate) async fn get_connection(
     amqp_uri: String,
     heartbeat_value: u16,
 ) -> Result<lapin::Connection, lapin::Error> {
@@ -49,7 +49,7 @@ pub async fn get_connection(
 /// ## Returns
 ///
 /// A lapin::Result<lapin::Channel> that holds the channel.
-pub async fn create_service_channel(
+pub(crate) async fn create_service_channel(
     conn: &Connection,
     service_name: &str,
     prefetch_count: u16,
@@ -96,7 +96,7 @@ pub async fn create_service_channel(
 /// ## Returns
 ///
 /// A lapin::Result<lapin::Channel> that holds the channel.
-pub async fn create_message_channel(
+pub(crate) async fn create_message_channel(
     conn: &Connection,
     rpc_queue_reply: &str,
     prefetch_count: u16,

--- a/girolle/src/rpc_client.rs
+++ b/girolle/src/rpc_client.rs
@@ -1,9 +1,8 @@
 use crate::config::Config;
+use crate::error::{GirolleError, RemoteError};
 use crate::payload::Payload;
 use crate::queue::{create_message_channel, create_service_channel, get_connection};
 use crate::types::GirolleResult;
-use crate::error::{GirolleError, RemoteError};
-use std::time::{Duration, SystemTime,SystemTimeError};
 use futures::executor;
 use lapin::{
     message::DeliveryResult,
@@ -13,6 +12,7 @@ use lapin::{
 };
 use serde_json::Value;
 use std::collections::HashMap;
+use std::time::{Duration, SystemTime, SystemTimeError};
 use std::{
     collections::BTreeMap,
     sync::{Arc, Mutex},
@@ -300,7 +300,8 @@ impl RpcClient {
                         Some(_error) => {
                             //error!("Error: {:?}", error);
                             //eprintln!("Error: {:?}", error);
-                            let e: RemoteError = serde_json::from_value(value["error"].clone()).unwrap();
+                            let e: RemoteError =
+                                serde_json::from_value(value["error"].clone()).unwrap();
                             return Err(e.convert_to_girolle_error());
                         }
                         None => {
@@ -353,13 +354,12 @@ impl RpcClient {
         Ok(RpcResult::new(
             self._result(&rpc_event)?,
             rpc_event.get_elapsed_time()?,
-
         ))
     }
     fn service_exist(&self, service_name: &str) -> bool {
         self.services.contains_key(service_name)
     }
-    
+
     /// # get_config
     ///
     /// ## Description
@@ -527,18 +527,20 @@ impl TargetService {
     }
 }
 /// # RpcReply
-/// 
+///
 /// ## Description
-/// 
+///
 /// This struct is used to create a RPC reply. It contains the correlation_id and the time_stamp
 pub struct RpcReply {
     correlation_id: uuid::Uuid,
     time_stamp: SystemTime,
-
 }
 impl RpcReply {
     fn new(correlation_id: uuid::Uuid) -> Self {
-        Self { correlation_id, time_stamp: SystemTime::now()}
+        Self {
+            correlation_id,
+            time_stamp: SystemTime::now(),
+        }
     }
     pub fn get_correlation_id(&self) -> String {
         self.correlation_id.to_string()
@@ -549,9 +551,9 @@ impl RpcReply {
 }
 
 /// # RpcResult
-/// 
+///
 /// ## Description
-/// 
+///
 /// This struct is used to create a RPC result. It contains the result and the elapsed_time
 pub struct RpcResult {
     result: Value,
@@ -565,17 +567,17 @@ impl RpcResult {
         }
     }
     /// # get_result
-    /// 
+    ///
     /// ## Description
-    /// 
+    ///
     /// This function return the result of the RPC call as `serde_json::Value`
     pub fn get_value(&self) -> Value {
         self.result.clone()
     }
     /// # get_elapsed_time
-    /// 
+    ///
     /// ## Description
-    /// 
+    ///
     /// This function return the elapsed time of the RPC call as `std::time::Duration`
     pub fn get_elapsed_time(&self) -> Duration {
         self.elapsed_time

--- a/girolle/src/rpc_service.rs
+++ b/girolle/src/rpc_service.rs
@@ -1,16 +1,16 @@
-use crate::config::Config;
-use crate::error::{GirolleError, RemoteError};
-use crate::nameko_utils::{delivery_to_message_properties, get_id};
-use crate::queue::{create_service_channel, get_connection};
-use crate::rpc_task::RpcTask;
+use crate::{
+    config::Config,
+    error::{GirolleError, RemoteError},
+    nameko_utils::{delivery_to_message_properties, get_id},
+    queue::{create_service_channel, get_connection},
+    rpc_task::RpcTask,
+};
 use lapin::{message::DeliveryResult, options::*, types::FieldTable, BasicProperties, Channel};
 use serde::Deserialize;
 use serde_json::{json, Value};
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 use tokio::sync::Semaphore;
-use tracing::Level;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn, Level};
 use uuid::Uuid;
 
 /// # RpcService
@@ -504,7 +504,7 @@ async fn rpc_service(
                     .await
                 }
                 (None, false) => {
-                    error!("Service {} is not found", &incommig_service);
+                    warn!("Service {} is not found", &incommig_service);
                     let payload = get_error_payload(
                         GirolleError::UnknownService(format!(
                             "Service {} is not found",
@@ -523,7 +523,7 @@ async fn rpc_service(
                     .expect("Error publishing");
                 }
                 (None, true) => {
-                    error!("Method {} is not found", &incomming_method);
+                    warn!("Method {} is not found", &incomming_method);
                     let payload = get_error_payload(
                         GirolleError::MethodNotFound(format!(
                             "Method {} is not found",

--- a/girolle/src/types/mod.rs
+++ b/girolle/src/types/mod.rs
@@ -1,7 +1,6 @@
-use lapin;
 use serde_json;
 use serde_json::Value;
-use std::fmt;
+use crate::error::GirolleError;
 
 /// # Result
 ///
@@ -16,61 +15,3 @@ pub type GirolleResult<T> = std::result::Result<T, GirolleError>;
 /// This type is used to define the function to call in the RPC service it
 /// mainly simplify the code to manipulate a complexe type.
 pub type NamekoFunction = fn(&[Value]) -> GirolleResult<Value>;
-
-pub enum GirolleError {
-    SerdeJsonError(serde_json::Error),
-    LapinError(lapin::Error),
-    ArgumentsError(String),
-    IncorrectSignature(String),
-    RemoteError(String),
-    ServiceMissingError(String),
-    SystemTimeError(std::time::SystemTimeError),
-}
-
-impl fmt::Display for GirolleError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            GirolleError::SerdeJsonError(e) => write!(f, "Serde JSON error: {}", e),
-            GirolleError::LapinError(e) => write!(f, "Lapin error: {}", e),
-            GirolleError::ArgumentsError(e) => write!(f, "Arguments error: {}", e),
-            GirolleError::IncorrectSignature(e) => write!(f, "Incorrect signature: {}", e),
-            GirolleError::RemoteError(e) => write!(f, "Remote error: {}", e),
-            GirolleError::ServiceMissingError(e) => write!(f, "Service missing error: {}", e),
-            GirolleError::SystemTimeError(e) => write!(f, "System time error: {}", e),
-        }
-    }
-}
-
-impl fmt::Debug for GirolleError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            GirolleError::SerdeJsonError(e) => write!(f, "Serde JSON error: {:?}", e),
-            GirolleError::LapinError(e) => write!(f, "Lapin error: {:?}", e),
-            GirolleError::ArgumentsError(e) => write!(f, "Arguments error: {}", e),
-            GirolleError::IncorrectSignature(e) => write!(f, "Incorrect signature: {}", e),
-            GirolleError::RemoteError(e) => write!(f, "Remote error: {:?}", e),
-            GirolleError::ServiceMissingError(e) => write!(f, "Service missing error: {:?}", e),
-            GirolleError::SystemTimeError(e) => write!(f, "System time error: {:?}", e),
-        }
-    }
-}
-
-impl From<serde_json::Error> for GirolleError {
-    fn from(error: serde_json::Error) -> Self {
-        GirolleError::SerdeJsonError(error)
-    }
-}
-
-impl From<lapin::Error> for GirolleError {
-    fn from(error: lapin::Error) -> Self {
-        GirolleError::LapinError(error)
-    }
-}
-impl From<std::time::SystemTimeError> for GirolleError {
-    fn from(error: std::time::SystemTimeError) -> Self {
-        GirolleError::SystemTimeError(error)
-    }
-    
-}
-
-impl std::error::Error for GirolleError {}

--- a/girolle/src/types/mod.rs
+++ b/girolle/src/types/mod.rs
@@ -1,6 +1,6 @@
+use crate::error::GirolleError;
 use serde_json;
 use serde_json::Value;
-use crate::error::GirolleError;
 
 /// # Result
 ///

--- a/nameko-examples/nameko_simple.py
+++ b/nameko-examples/nameko_simple.py
@@ -1,0 +1,70 @@
+from nameko.standalone.rpc import ClusterRpcClient, config
+from nameko.exceptions import IncorrectSignature
+import os
+from datetime import datetime, timedelta
+import time
+
+CONFIG = {
+    "AMQP_URI": "pyamqp://{}:{}@{}/".format(
+        os.getenv("RABBITMQ_USER"),
+        os.getenv("RABBITMQ_PASSWORD"),
+        os.getenv("RABBITMQ_HOST"),
+    )
+}
+
+
+def rpc_proxy(CONFIG) -> ClusterRpcClient:
+    """
+    rpc_proxy load configuration paramter et init the setup
+
+    :param CONFIG: configuration param as a string
+    :type CONFIG: str
+    :return:
+    :rtype: ClusterRpcClient
+    """
+    config.setup(CONFIG)
+    return ClusterRpcClient(CONFIG)
+
+
+if __name__ == "__main__":
+    tempo = 4
+    with rpc_proxy(CONFIG) as client:
+        # test a simple messgae
+        response = client.video.fibonacci(30)
+        print(response)
+        assert 832040 == response
+        # test message with two arguments
+        assert 5 == client.video.sub(b=5, a=10)
+        assert 5 == client.video.sub(10, b=5)
+        # test kwargs
+        assert client.video.sub(10, 5) == 5
+        # test arguments error
+        try:
+            client.video.sub(b=5, a=10, c=4)
+        except IncorrectSignature as e:
+            print(e)
+        try:
+            client.video.sub(10)
+        except IncorrectSignature as e:
+            print(e)
+        try:
+            client.video.sub(10, 5, 4)
+        except IncorrectSignature as e:
+            print(e)
+        # make an async call
+        async_response = client.video.hello.call_async("Toto")
+        # make an sync call
+        response = client.video.hello("Girolle")
+        print(response)
+        assert "Hello, Girolle!" == response
+        time.sleep(tempo)
+        # get the result of the aysnc call
+        response_async = async_response.result()
+        print(response_async)
+        assert "Hello, Toto!" == response_async
+        # batch a pack of async call
+        start = datetime.now()
+        data: list = [[i, client.video.hello.call_async(str(i))] for i in range(1000)]
+        time.sleep(tempo)
+        results = [[d[0], d[1].result()] for d in data]
+        print(datetime.now() - start - timedelta(seconds=tempo))

--- a/nameko-examples/nameko_test.py
+++ b/nameko-examples/nameko_test.py
@@ -1,5 +1,5 @@
 from nameko.standalone.rpc import ClusterRpcClient, config
-from nameko.exceptions import IncorrectSignature
+from nameko.exceptions import IncorrectSignature,MethodNotFound,UnknownService
 import os
 from datetime import datetime, timedelta
 import time
@@ -50,6 +50,14 @@ if __name__ == "__main__":
         try:
             client.video.sub(10, 5, 4)
         except IncorrectSignature as e:
+            print(e)
+        try:
+            client.video.plus(10,5)
+        except MethodNotFound as e:
+            print(e)
+        try:
+            client.hello.hello("Toto")
+        except UnknownService as e:
             print(e)
         # make an async call
         async_response = client.video.hello.call_async("Toto")

--- a/tests/nameko_test.py
+++ b/tests/nameko_test.py
@@ -1,5 +1,5 @@
 from nameko.standalone.rpc import ClusterRpcClient, config
-from nameko.exceptions import IncorrectSignature,MethodNotFound,UnknownService
+from nameko.exceptions import IncorrectSignature, MethodNotFound, UnknownService
 import os
 from datetime import datetime, timedelta
 import time
@@ -52,7 +52,7 @@ if __name__ == "__main__":
         except IncorrectSignature as e:
             print(e)
         try:
-            client.video.plus(10,5)
+            client.video.plus(10, 5)
         except MethodNotFound as e:
             print(e)
         try:
@@ -72,7 +72,7 @@ if __name__ == "__main__":
         assert "Hello, Toto!" == response_async
         # batch a pack of async call
         start = datetime.now()
-        data: list = [[i, client.video.hello.call_async(str(i))] for i in range(1000)]
+        data: list = [[i, client.video.hello.call_async(str(i))] for i in range(10)]
         time.sleep(tempo)
         results = [[d[0], d[1].result()] for d in data]
         print(datetime.now() - start - timedelta(seconds=tempo))


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced `GirolleError` enum for comprehensive error handling across the library.
- Refactored RPC client and service to integrate new error handling mechanisms.
- Added new examples and tests to demonstrate and verify error handling.
- Improved code readability and structure through formatting and refactoring.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>error_sender.rs</strong><dd><code>Add error handling example with `RpcClient`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
examples/error_sender.rs

<li>Added a new example to demonstrate error handling with <code>RpcClient</code>.<br> <li> Includes various RPC calls and error assertions.<br> <li> Utilizes <code>Payload</code> for argument passing.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/120/files#diff-4fd1958bf4b5408761b5489cf96d96f65e6ab36ebac6cb2097c23bcdba4d0515">+75/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>simple_sender.rs</strong><dd><code>Refactor simple sender example for readability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
examples/simple_sender.rs

<li>Refactored code for better readability.<br> <li> Added formatted assertions and print statements.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/120/files#diff-06d62d03dd0ff3cc6b743299af8917c4529585dfd695f7892a78e3938e0baf5f">+16/-4</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add `GirolleError` enum for comprehensive error handling</code>&nbsp; </dd></summary>
<hr>
      
girolle/src/error/mod.rs

<li>Introduced <code>GirolleError</code> enum for various error types.<br> <li> Implemented <code>Display</code> and <code>Debug</code> traits for <code>GirolleError</code>.<br> <li> Added conversion methods between <code>GirolleError</code> and <code>RemoteError</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/120/files#diff-5084a54a42f4874322fd744d1c22ce4386dea00bf52cbc162ac0a957987c864a">+123/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Expose `GirolleError` in library</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/lib.rs

- Exposed `GirolleError` in the library.



</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/120/files#diff-df51b0b24fbb629077ebc369346fae19e9b27be8c799d416dfc3bb3e747d3cde">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Enhance message properties and error handling utilities</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/nameko_utils/mod.rs

<li>Added functions for message properties and error handling.<br> <li> Refactored existing functions for internal use.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/120/files#diff-6ca6455bb90f53eb0ef288bb592ce44e91fda2f73de6f8953280817497cd9000">+217/-2</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Restrict visibility of queue functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/queue/mod.rs

- Changed visibility of functions to `pub(crate)`.



</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/120/files#diff-0077581ee5d731afe306563568767b5fdbc4442867c3ff4208f57a0c5e2fbb33">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_client.rs</strong><dd><code>Integrate `GirolleError` in RPC client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/rpc_client.rs

<li>Integrated <code>GirolleError</code> for error handling.<br> <li> Refactored RPC client methods for better error management.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/120/files#diff-a9fe91e540be452dba08af8646f6d3ab4453ab253a7791cb7db45bbdf0729aa9">+23/-19</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_service.rs</strong><dd><code>Refactor RPC service for improved error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/rpc_service.rs

<li>Refactored RPC service to use new error handling mechanisms.<br> <li> Removed redundant code and improved structure.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/120/files#diff-905fc53bd11f000b1d04f3652165202c7e78c765664736b6908058150c364ed2">+75/-222</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Update types to use new `GirolleError`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/types/mod.rs

<li>Removed old <code>GirolleError</code> definition.<br> <li> Updated type definitions to use new <code>GirolleError</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/120/files#diff-7093d4995ff475654107769e9dde05c11ce49cb339adfd46bb0b7d4dad75e1c0">+1/-60</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>nameko_simple.py</strong><dd><code>Add Nameko RPC client example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
nameko-examples/nameko_simple.py

<li>Added a new example to demonstrate Nameko RPC client usage.<br> <li> Includes various RPC calls and error handling.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/120/files#diff-d0ac07d4b069b039617036cfb837de86b565d2726be2e0b8d629b3bd5f4edd1f">+71/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Formatting
</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Format payload module for readability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/payload/mod.rs

- Formatted code for better readability.



</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/120/files#diff-80b7ed32e0a4c284bde785e21a92e4a71f76a3781a5461e70a446588b4e1d2af">+10/-7</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>prelude.rs</strong><dd><code>Format prelude module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/prelude.rs

- Minor formatting changes.



</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/120/files#diff-4596cac6f7b5ee44fff37db2460827f9daa07e422d7002a7f380404e1c40460d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>nameko_test.py</strong><dd><code>Add tests for Nameko RPC client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
tests/nameko_test.py

<li>Added tests for Nameko RPC client.<br> <li> Includes assertions for various RPC calls and error scenarios.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/120/files#diff-55145e646a0067ca948292dcd7066dc99c32f06fdacea0e3adb0c0ba9f5d82af">+78/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Register new example in Cargo.toml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
examples/Cargo.toml

- Added new example `error_sender` to the Cargo.toml.



</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/120/files#diff-a07b01c0e1bcaddea88402d286352d4fdf8fb3de57a136e1879402517366cc16">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

