### PR TITLE
125 use payload struct to deserialize the incomming payload

### DIFF
--- a/girolle/src/error/mod.rs
+++ b/girolle/src/error/mod.rs
@@ -92,6 +92,12 @@ impl GirolleError {
                 value: e.clone(),
                 exc_args: vec![e.clone()],
             },
+            GirolleError::SerdeJsonError(e) => RemoteError {
+                exc_path: "nameko.exceptions.RemoteError".to_string(),
+                exc_type: "JsonError".to_string(),
+                value: e.to_string(),
+                exc_args: vec![e.to_string()],
+            },
             _ => RemoteError {
                 exc_path: "".to_string(),
                 exc_type: "".to_string(),

--- a/girolle/src/nameko_utils/mod.rs
+++ b/girolle/src/nameko_utils/mod.rs
@@ -1,6 +1,6 @@
 use crate::error::GirolleError;
-use crate::rpc_task::RpcTask;
 use crate::payload::{Payload, PayloadResult};
+use crate::rpc_task::RpcTask;
 use lapin::options::BasicPublishOptions;
 /// # nameko_utils
 ///

--- a/girolle/src/nameko_utils/mod.rs
+++ b/girolle/src/nameko_utils/mod.rs
@@ -210,7 +210,7 @@ pub(crate) async fn compute_deliver(
         Err(error) => {
             publish(
                 &rpc_channel,
-                PayloadResult::new(Value::Null, Some(error.convert())),
+                PayloadResult::from_error(error.convert()),
                 properties,
                 reply_to_id,
                 rpc_exchange,
@@ -224,7 +224,7 @@ pub(crate) async fn compute_deliver(
         Ok(result) => {
             publish(
                 &rpc_channel,
-                PayloadResult::new(result, None),
+                PayloadResult::from_result_value(result),
                 properties,
                 reply_to_id,
                 rpc_exchange,
@@ -236,7 +236,7 @@ pub(crate) async fn compute_deliver(
         Err(error) => {
             publish(
                 &rpc_channel,
-                PayloadResult::new(Value::Null, Some(error.convert())),
+                PayloadResult::from_error(error.convert()),
                 properties,
                 reply_to_id,
                 rpc_exchange,

--- a/girolle/src/nameko_utils/mod.rs
+++ b/girolle/src/nameko_utils/mod.rs
@@ -109,7 +109,10 @@ pub(crate) async fn publish(
                 &rpc_exchange_clone,
                 &format!("{}", &reply_to_id),
                 BasicPublishOptions::default(),
-                payload.to_string().as_bytes(),
+                payload
+                    .to_string()
+                    .expect("can't serialize payload")
+                    .as_bytes(),
                 properties,
             )
             .await

--- a/girolle/src/nameko_utils/mod.rs
+++ b/girolle/src/nameko_utils/mod.rs
@@ -1,4 +1,4 @@
-use crate::error::{GirolleError, RemoteError};
+use crate::error::GirolleError;
 use crate::rpc_task::RpcTask;
 use crate::payload::{Payload, PayloadResult};
 use lapin::options::BasicPublishOptions;
@@ -8,7 +8,7 @@ use lapin::options::BasicPublishOptions;
 use lapin::types::{AMQPValue, FieldTable, LongString, ShortString};
 use lapin::Channel;
 use lapin::{message::Delivery, BasicProperties};
-use serde_json::{json, Value};
+use serde_json::Value;
 use std::collections::HashMap;
 use tracing::error;
 use uuid::Uuid;

--- a/girolle/src/nameko_utils/mod.rs
+++ b/girolle/src/nameko_utils/mod.rs
@@ -1,5 +1,6 @@
 use crate::error::{GirolleError, RemoteError};
 use crate::rpc_task::RpcTask;
+use crate::payload::Payload;
 use lapin::options::BasicPublishOptions;
 /// # nameko_utils
 ///
@@ -142,7 +143,7 @@ fn push_values_to_result(
 
 fn build_inputs_fn_service(
     service_args: &Vec<&str>,
-    data_delivery: DeliveryData,
+    data_delivery: Payload,
 ) -> Result<Vec<Value>, GirolleError> {
     let args_size: usize = data_delivery.args.len();
     let kwargs_size: usize = data_delivery.kwargs.len();
@@ -178,7 +179,7 @@ fn build_inputs_fn_service(
 #[test]
 fn test_build_inputs_fn_service() {
     let service_args = vec!["a", "b", "c"];
-    let data_delivery = DeliveryData {
+    let data_delivery = Payload {
         args: vec![
             Value::String("1".to_string()),
             Value::String("2".to_string()),
@@ -213,14 +214,9 @@ pub(crate) fn get_error_payload(error: RemoteError) -> String {
     )
     .to_string()
 }
-#[derive(Debug, Deserialize)]
-pub struct DeliveryData {
-    args: Vec<Value>,
-    kwargs: HashMap<String, Value>,
-}
 /// Execute the delivery
 pub(crate) async fn compute_deliver(
-    incomming_data: DeliveryData,
+    incomming_data: Payload,
     properties: BasicProperties,
     rpc_task_struct: &RpcTask,
     rpc_channel: &Channel,

--- a/girolle/src/payload/mod.rs
+++ b/girolle/src/payload/mod.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 use crate::error::RemoteError;
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Payload {
-    pub (crate) args: Vec<Value>,
-    pub (crate) kwargs: HashMap<String, Value>,
+    pub(crate) args: Vec<Value>,
+    pub(crate) kwargs: HashMap<String, Value>,
 }
 impl Payload {
     /// # new
@@ -106,9 +106,9 @@ impl Payload {
         self
     }
     /// # to_string
-    /// 
+    ///
     /// ## Description
-    /// 
+    ///
     /// Serialize the Payload to a json string
     pub fn to_string(&self) -> String {
         serde_json::to_string(self).unwrap()
@@ -132,55 +132,55 @@ impl Payload {
 }
 
 /// # PayloadResult
-/// 
+///
 /// ## Description
-/// 
+///
 /// Struct to handle the result to send back to the client
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub (crate) struct PayloadResult{
+pub(crate) struct PayloadResult {
     result: Value,
     error: Option<RemoteError>,
 }
-impl PayloadResult{
+impl PayloadResult {
     /// # get_error
-    /// 
+    ///
     /// ## Description
-    /// 
+    ///
     /// Get the error from the PayloadResult
-    pub (crate) fn get_error(&self) -> Option<RemoteError> {
+    pub(crate) fn get_error(&self) -> Option<RemoteError> {
         self.error.clone()
     }
     /// # get_result
-    /// 
+    ///
     /// ## Description
-    /// 
+    ///
     /// Get the result from the PayloadResult
-    pub (crate) fn get_result(&self) -> Value {
+    pub(crate) fn get_result(&self) -> Value {
         self.result.clone()
     }
     /// # from_result_value
-    /// 
+    ///
     /// ## Description
-    /// 
+    ///
     /// Create a new PayloadResult from a Value
-    pub (crate) fn from_result_value(result: Value) -> Self {
+    pub(crate) fn from_result_value(result: Value) -> Self {
         Self {
             result,
             error: None,
         }
     }
     /// # from_error
-    /// 
+    ///
     /// ## Description
-    /// 
+    ///
     /// Create a new PayloadResult from a RemoteError
-    pub (crate) fn from_error(error: RemoteError) -> Self {
+    pub(crate) fn from_error(error: RemoteError) -> Self {
         Self {
             result: Value::Null,
             error: Some(error),
         }
     }
-    pub (crate) fn to_string(&self) -> String {
+    pub(crate) fn to_string(&self) -> String {
         serde_json::to_string(self).unwrap()
     }
 }

--- a/girolle/src/payload/mod.rs
+++ b/girolle/src/payload/mod.rs
@@ -180,7 +180,7 @@ impl PayloadResult {
             error: Some(error),
         }
     }
-    pub(crate) fn to_string(&self) -> String {
-        serde_json::to_string(self).unwrap()
+    pub(crate) fn to_string(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
     }
 }

--- a/girolle/src/payload/mod.rs
+++ b/girolle/src/payload/mod.rs
@@ -105,6 +105,11 @@ impl Payload {
         );
         self
     }
+    /// # to_string
+    /// 
+    /// ## Description
+    /// 
+    /// Serialize the Payload to a json string
     pub fn to_string(&self) -> String {
         serde_json::to_string(self).unwrap()
     }
@@ -126,25 +131,56 @@ impl Payload {
     }
 }
 
+/// # PayloadResult
+/// 
+/// ## Description
+/// 
+/// Struct to handle the result to send back to the client
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub (crate) struct PayloadResult{
     result: Value,
     error: Option<RemoteError>,
 }
 impl PayloadResult{
-    pub fn get_error(&self) -> Option<RemoteError> {
+    /// # get_error
+    /// 
+    /// ## Description
+    /// 
+    /// Get the error from the PayloadResult
+    pub (crate) fn get_error(&self) -> Option<RemoteError> {
         self.error.clone()
     }
-    pub fn get_result(&self) -> Value {
+    /// # get_result
+    /// 
+    /// ## Description
+    /// 
+    /// Get the result from the PayloadResult
+    pub (crate) fn get_result(&self) -> Value {
         self.result.clone()
     }
-    pub fn new(result: Value, error: Option<RemoteError>) -> Self {
+    /// # from_result_value
+    /// 
+    /// ## Description
+    /// 
+    /// Create a new PayloadResult from a Value
+    pub (crate) fn from_result_value(result: Value) -> Self {
         Self {
             result,
-            error,
+            error: None,
         }
     }
-    pub fn to_string(&self) -> String {
+    /// # from_error
+    /// 
+    /// ## Description
+    /// 
+    /// Create a new PayloadResult from a RemoteError
+    pub (crate) fn from_error(error: RemoteError) -> Self {
+        Self {
+            result: Value::Null,
+            error: Some(error),
+        }
+    }
+    pub (crate) fn to_string(&self) -> String {
         serde_json::to_string(self).unwrap()
     }
 }

--- a/girolle/src/payload/mod.rs
+++ b/girolle/src/payload/mod.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
+
+use crate::error::RemoteError;
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Payload {
     args: Vec<Value>,
@@ -122,4 +124,10 @@ impl Payload {
     pub fn is_empty(&self) -> bool {
         self.args.is_empty() && self.kwargs.is_empty()
     }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PayloadResult{
+    result: Value,
+    error: Option<RemoteError>,
 }

--- a/girolle/src/payload/mod.rs
+++ b/girolle/src/payload/mod.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 use crate::error::RemoteError;
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Payload {
-    args: Vec<Value>,
-    kwargs: HashMap<String, Value>,
+    pub (crate) args: Vec<Value>,
+    pub (crate) kwargs: HashMap<String, Value>,
 }
 impl Payload {
     /// # new

--- a/girolle/src/payload/mod.rs
+++ b/girolle/src/payload/mod.rs
@@ -127,7 +127,7 @@ impl Payload {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct PayloadResult{
+pub (crate) struct PayloadResult{
     result: Value,
     error: Option<RemoteError>,
 }

--- a/girolle/src/payload/mod.rs
+++ b/girolle/src/payload/mod.rs
@@ -138,4 +138,13 @@ impl PayloadResult{
     pub fn get_result(&self) -> Value {
         self.result.clone()
     }
+    pub fn new(result: Value, error: Option<RemoteError>) -> Self {
+        Self {
+            result,
+            error,
+        }
+    }
+    pub fn to_string(&self) -> String {
+        serde_json::to_string(self).unwrap()
+    }
 }

--- a/girolle/src/payload/mod.rs
+++ b/girolle/src/payload/mod.rs
@@ -131,3 +131,14 @@ pub struct PayloadResult{
     result: Value,
     error: Option<RemoteError>,
 }
+impl PayloadResult{
+    pub fn is_error(&self) -> bool {
+        self.error.is_some()
+    }
+    pub fn get_error(&self) -> Option<RemoteError> {
+        self.error.clone()
+    }
+    pub fn get_result(&self) -> Value {
+        self.result.clone()
+    }
+}

--- a/girolle/src/payload/mod.rs
+++ b/girolle/src/payload/mod.rs
@@ -132,9 +132,6 @@ pub struct PayloadResult{
     error: Option<RemoteError>,
 }
 impl PayloadResult{
-    pub fn is_error(&self) -> bool {
-        self.error.is_some()
-    }
     pub fn get_error(&self) -> Option<RemoteError> {
         self.error.clone()
     }

--- a/girolle/src/rpc_client.rs
+++ b/girolle/src/rpc_client.rs
@@ -130,11 +130,12 @@ impl RpcClient {
             let not_empty = not_empty.clone();
             async move {
                 if let Ok(Some(delivery)) = delivery {
-                    let correlation_id = delivery.properties.correlation_id().clone();
+                    let correlation_id: Option<lapin::types::ShortString> =
+                        delivery.properties.correlation_id().clone();
                     let payload: PayloadResult = match serde_json::from_slice(&delivery.data) {
                         Ok(payload) => payload,
                         Err(e) => {
-                            error!("Error: {:?}", e);
+                            error!(error = %e, "Deserialization failed");
                             let error = GirolleError::SerdeJsonError(e);
                             PayloadResult::from_error(error.convert())
                         }

--- a/girolle/src/rpc_client.rs
+++ b/girolle/src/rpc_client.rs
@@ -10,7 +10,6 @@ use lapin::{
     types::{AMQPValue, FieldArray, FieldTable},
     BasicProperties, Connection,
 };
-use serde::de::value;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Condvar;

--- a/girolle/src/rpc_client.rs
+++ b/girolle/src/rpc_client.rs
@@ -10,6 +10,7 @@ use lapin::{
     types::{AMQPValue, FieldArray, FieldTable},
     BasicProperties, Connection,
 };
+use serde::de::value;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Condvar;
@@ -302,15 +303,14 @@ impl RpcClient {
             Some(_error) => {
                 //error!("Error: {:?}", error);
                 //eprintln!("Error: {:?}", error);
-                let e: RemoteError =
-                    serde_json::from_value(result_reply["error"].take()).unwrap();
+                let e: RemoteError = serde_json::from_value(result_reply["error"].take()).unwrap();
                 return Err(e.convert_to_girolle_error());
             }
             None => {
                 return Ok(result_reply["result"].take());
             }
-            };
-        }
+        };
+    }
     /// # send
     ///
     /// ## Description

--- a/girolle/src/rpc_client.rs
+++ b/girolle/src/rpc_client.rs
@@ -1,5 +1,5 @@
 use crate::config::Config;
-use crate::error::{GirolleError, RemoteError};
+use crate::error::GirolleError;
 use crate::payload::{Payload, PayloadResult};
 use crate::queue::{create_message_channel, create_service_channel, get_connection};
 use crate::types::GirolleResult;

--- a/girolle/src/rpc_client.rs
+++ b/girolle/src/rpc_client.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use crate::error::{GirolleError, RemoteError};
-use crate::payload::Payload;
+use crate::payload::{Payload,PayloadResult};
 use crate::queue::{create_message_channel, create_service_channel, get_connection};
 use crate::types::GirolleResult;
 use futures::executor;
@@ -43,8 +43,8 @@ pub struct RpcClient {
     conn: Connection,
     reply_channel: lapin::Channel,
     services: HashMap<String, TargetService>,
-    replies: Arc<Mutex<HashMap<String, Value>>>,
     not_empty: Arc<Condvar>,
+    replies: Arc<Mutex<HashMap<String, PayloadResult>>>,
 }
 impl RpcClient {
     /// # new

--- a/girolle/src/rpc_service.rs
+++ b/girolle/src/rpc_service.rs
@@ -330,7 +330,7 @@ async fn rpc_service(
                         .convert();
                     publish(
                         &shared_data_clone.rpc_channel,
-                        PayloadResult::new(serde_json::Value::Null, Some(payload)),
+                        PayloadResult::from_error(payload),
                         properties,
                         reply_to_id,
                         &shared_data_clone.rpc_exchange,
@@ -348,7 +348,7 @@ async fn rpc_service(
                         .convert();
                     publish(
                         &shared_data_clone.rpc_channel,
-                        PayloadResult::new(serde_json::Value::Null, Some(payload)),
+                        PayloadResult::from_error(payload),
                         properties,
                         reply_to_id,
                         &shared_data_clone.rpc_exchange,

--- a/girolle/src/rpc_service.rs
+++ b/girolle/src/rpc_service.rs
@@ -1,7 +1,10 @@
 use crate::{
-    config::Config, error::GirolleError, nameko_utils::{
-        compute_deliver, delivery_to_message_properties, get_id, publish,
-    }, payload::{Payload, PayloadResult}, queue::{create_service_channel, get_connection}, rpc_task::RpcTask
+    config::Config,
+    error::GirolleError,
+    nameko_utils::{compute_deliver, delivery_to_message_properties, get_id, publish},
+    payload::{Payload, PayloadResult},
+    queue::{create_service_channel, get_connection},
+    rpc_task::RpcTask,
 };
 use lapin::{message::DeliveryResult, options::*, types::FieldTable, Channel};
 use std::{collections::HashMap, sync::Arc};
@@ -322,12 +325,11 @@ async fn rpc_service(
                 }
                 (None, false) => {
                     warn!("Service {} is not found", &incommig_service);
-                    let payload = 
-                        GirolleError::UnknownService(format!(
-                            "Service {} is not found",
-                            &incommig_service,
-                        ))
-                        .convert();
+                    let payload = GirolleError::UnknownService(format!(
+                        "Service {} is not found",
+                        &incommig_service,
+                    ))
+                    .convert();
                     publish(
                         &shared_data_clone.rpc_channel,
                         PayloadResult::from_error(payload),
@@ -340,12 +342,11 @@ async fn rpc_service(
                 }
                 (None, true) => {
                     warn!("Method {} is not found", &incomming_method);
-                    let payload = 
-                        GirolleError::MethodNotFound(format!(
-                            "Method {} is not found",
-                            &incomming_method,
-                        ))
-                        .convert();
+                    let payload = GirolleError::MethodNotFound(format!(
+                        "Method {} is not found",
+                        &incomming_method,
+                    ))
+                    .convert();
                     publish(
                         &shared_data_clone.rpc_channel,
                         PayloadResult::from_error(payload),

--- a/girolle/src/rpc_service.rs
+++ b/girolle/src/rpc_service.rs
@@ -3,10 +3,10 @@ use crate::{
     error::GirolleError,
     nameko_utils::{
         compute_deliver, delivery_to_message_properties, get_error_payload, get_id, publish,
-        DeliveryData,
     },
     queue::{create_service_channel, get_connection},
     rpc_task::RpcTask,
+    payload::Payload,
 };
 use lapin::{message::DeliveryResult, options::*, types::FieldTable, Channel};
 use std::{collections::HashMap, sync::Arc};
@@ -313,7 +313,7 @@ async fn rpc_service(
                 incommig_service == &shared_data_clone.service_name,
             ) {
                 (Some(rpc_task_struct), _) => {
-                    let incomming_data: DeliveryData = serde_json::from_slice(&delivery.data)
+                    let incomming_data: Payload = serde_json::from_slice(&delivery.data)
                         .expect("Can't deserialize incomming data");
                     compute_deliver(
                         incomming_data,

--- a/girolle/src/rpc_service.rs
+++ b/girolle/src/rpc_service.rs
@@ -1,12 +1,7 @@
 use crate::{
-    config::Config,
-    error::GirolleError,
-    nameko_utils::{
-        compute_deliver, delivery_to_message_properties, get_error_payload, get_id, publish,
-    },
-    queue::{create_service_channel, get_connection},
-    rpc_task::RpcTask,
-    payload::Payload,
+    config::Config, error::GirolleError, nameko_utils::{
+        compute_deliver, delivery_to_message_properties, get_id, publish,
+    }, payload::{Payload, PayloadResult}, queue::{create_service_channel, get_connection}, rpc_task::RpcTask
 };
 use lapin::{message::DeliveryResult, options::*, types::FieldTable, Channel};
 use std::{collections::HashMap, sync::Arc};
@@ -327,16 +322,15 @@ async fn rpc_service(
                 }
                 (None, false) => {
                     warn!("Service {} is not found", &incommig_service);
-                    let payload = get_error_payload(
+                    let payload = 
                         GirolleError::UnknownService(format!(
                             "Service {} is not found",
                             &incommig_service,
                         ))
-                        .convert(),
-                    );
+                        .convert();
                     publish(
                         &shared_data_clone.rpc_channel,
-                        payload,
+                        PayloadResult::new(serde_json::Value::Null, Some(payload)),
                         properties,
                         reply_to_id,
                         &shared_data_clone.rpc_exchange,
@@ -346,16 +340,15 @@ async fn rpc_service(
                 }
                 (None, true) => {
                     warn!("Method {} is not found", &incomming_method);
-                    let payload = get_error_payload(
+                    let payload = 
                         GirolleError::MethodNotFound(format!(
                             "Method {} is not found",
                             &incomming_method,
                         ))
-                        .convert(),
-                    );
+                        .convert();
                     publish(
                         &shared_data_clone.rpc_channel,
-                        payload,
+                        PayloadResult::new(serde_json::Value::Null, Some(payload)),
                         properties,
                         reply_to_id,
                         &shared_data_clone.rpc_exchange,


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored `RpcClient` to use `Condvar` for thread synchronization and updated it to use `PayloadResult` for replies.
- Replaced `DeliveryData` with `Payload` in `nameko_utils` and `rpc_service` modules.
- Added `PayloadResult` struct for handling RPC client payloads, including methods for error handling and result retrieval.
- Improved error handling by adding `SerdeJsonError` in `GirolleError`.
- Removed unused imports and updated serde_json dependency in `nameko_utils`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add SerdeJsonError handling in GirolleError</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/error/mod.rs

- Added handling for `SerdeJsonError` in `GirolleError`.



</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/127/files#diff-5084a54a42f4874322fd744d1c22ce4386dea00bf52cbc162ac0a957987c864a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Refactor nameko_utils to use Payload and PayloadResult</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/nameko_utils/mod.rs

<li>Replaced <code>DeliveryData</code> with <code>Payload</code>.<br> <li> Updated functions to use <code>PayloadResult</code>.<br> <li> Removed unused imports and updated serde_json dependency.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/127/files#diff-6ca6455bb90f53eb0ef288bb592ce44e91fda2f73de6f8953280817497cd9000">+11/-35</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add PayloadResult struct and update Payload methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/payload/mod.rs

<li>Added <code>PayloadResult</code> struct for handling RPC client payloads.<br> <li> Added methods to <code>PayloadResult</code> for error handling and result <br>retrieval.<br> <li> Updated <code>Payload</code> struct with new methods.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/127/files#diff-80b7ed32e0a4c284bde785e21a92e4a71f76a3781a5461e70a446588b4e1d2af">+63/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_client.rs</strong><dd><code>Refactor RpcClient to use Condvar and PayloadResult</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/rpc_client.rs

<li>Refactored <code>RpcClient</code> to use <code>Condvar</code> for thread synchronization.<br> <li> Updated <code>RpcClient</code> to use <code>PayloadResult</code> for replies.<br> <li> Improved error handling in <code>RpcClient</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/127/files#diff-a9fe91e540be452dba08af8646f6d3ab4453ab253a7791cb7db45bbdf0729aa9">+18/-13</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_service.rs</strong><dd><code>Update rpc_service to use Payload and PayloadResult</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/rpc_service.rs

<li>Replaced <code>DeliveryData</code> with <code>Payload</code>.<br> <li> Updated error handling to use <code>PayloadResult</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/127/files#diff-905fc53bd11f000b1d04f3652165202c7e78c765664736b6908058150c364ed2">+15/-21</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

