### PR TITLE
feat: Add parent_calls_tracked parameter to Config and update related…

### DIFF
--- a/girolle/src/config/mod.rs
+++ b/girolle/src/config/mod.rs
@@ -218,6 +218,9 @@ impl Config {
     pub fn max_workers(&self) -> u32 {
         self.max_workers.unwrap()
     }
+    pub fn parent_calls_tracked(&self) -> u32 {
+        self.parent_calls_tracked.unwrap()
+    }
     /// # with_amqp_uri
     ///
     /// ## Description


### PR DESCRIPTION
### **User description**
… functions


___

### **PR Type**
Enhancement


___

### **Description**
- Added `parent_calls_tracked` method to `Config` struct.
- Updated `insert_new_id_to_call_id` and `delivery_to_message_properties` functions to include `parent_calls_tracked` parameter.
- Added logic to limit the size of `call_id_stack` based on `parent_calls_tracked`.
- Integrated `parent_calls_tracked` into `rpc_service` by adding it to `SharedData` and passing it to relevant functions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Add `parent_calls_tracked` method to `Config` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/config/mod.rs

- Added `parent_calls_tracked` method to `Config` struct.



</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/130/files#diff-7e45d463d466af8d4e5d02abc995ed7f40485bc0a4bd1a5b0aced1497ffd3563">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Update functions to track parent calls with limit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/nameko_utils/mod.rs

<li>Added <code>parent_calls_tracked</code> parameter to <code>insert_new_id_to_call_id</code> <br>function.<br> <li> Added logic to limit the size of <code>call_id_stack</code> based on <br><code>parent_calls_tracked</code>.<br> <li> Updated <code>delivery_to_message_properties</code> function to include <br><code>parent_calls_tracked</code> parameter.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/130/files#diff-6ca6455bb90f53eb0ef288bb592ce44e91fda2f73de6f8953280817497cd9000">+13/-4</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rpc_service.rs</strong><dd><code>Integrate `parent_calls_tracked` into RPC service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
girolle/src/rpc_service.rs

<li>Added <code>parent_calls_tracked</code> field to <code>SharedData</code> struct.<br> <li> Updated <code>rpc_service</code> function to initialize <code>parent_calls_tracked</code> from <br>config.<br> <li> Modified delegate logic to pass <code>parent_calls_tracked</code> to <br><code>delivery_to_message_properties</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/130/files#diff-905fc53bd11f000b1d04f3652165202c7e78c765664736b6908058150c364ed2">+13/-11</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

