### PR TITLE
chore: Update zola-deploy-action to v0.18.0

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -10,7 +10,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3.0.0
       - name: build_and_deploy
-        uses: shalzz/zola-deploy-action@master
+        uses: shalzz/zola-deploy-action@v0.18.0
         env:
           # Target branch
           BUILD_DIR: docs


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Updated `zola-deploy-action` to version `v0.18.0` in the GitHub workflow configuration file `.github/workflows/doc.yml`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>doc.yml</strong><dd><code>Update `zola-deploy-action` to v0.18.0 in GitHub workflow</code></dd></summary>
<hr>

.github/workflows/doc.yml

- Updated `zola-deploy-action` to version `v0.18.0`.



</details>


  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/135/files#diff-7871fa1d10e6bf511d9cfda5a6874d1a75acb950fb1bc9fee6057eff13257521">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

