### PR TITLE
feat: Add benchmark for build_inputs_fn_service function

### DIFF
--- a/girolle/benches/macro.rs
+++ b/girolle/benches/macro.rs
@@ -1,6 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use girolle::prelude::*;
+use girolle::nameko_utils::build_inputs_fn_service;
 use serde_json::Value;
 
 fn fibonacci_fast(n: u64) -> u64 {
@@ -39,5 +40,20 @@ fn bench_macro(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_macro);
+
+
+fn bench_build_inputs_fn_service(c: &mut Criterion) {
+    let mut group = c.benchmark_group("build_inputs_fn_service");
+    let service_args = vec!["a", "b", "c"];
+    let data_delivery = Payload::new()
+        .arg("1")
+        .arg("2")
+        .kwarg("c", "3");
+    group.bench_function("build_inputs_fn_service", |b| {
+        b.iter(|| build_inputs_fn_service(&service_args, data_delivery.clone()))
+    });
+    group.finish();
+}
+
+criterion_group!(name = benches;config = Criterion::default(); targets= bench_macro, bench_build_inputs_fn_service);
 criterion_main!(benches);

--- a/girolle/src/lib.rs
+++ b/girolle/src/lib.rs
@@ -50,7 +50,8 @@ mod config;
 mod queue;
 pub mod types;
 pub use config::Config;
-mod nameko_utils;
+// Public for bench purpose
+pub mod nameko_utils;
 pub mod prelude;
 mod rpc_client;
 pub use rpc_client::RpcClient;


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added a new benchmark function `bench_build_inputs_fn_service` to test the performance of `build_inputs_fn_service`.
- Made the `nameko_utils` module public to allow benchmarking.
- Refactored the `push_values_to_result` function for cleaner code.
- Simplified the logic in `build_inputs_fn_service` for checking argument sizes and made it public.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>macro.rs</strong><dd><code>Add benchmark for `build_inputs_fn_service` function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

girolle/benches/macro.rs

<li>Added a new benchmark function <code>bench_build_inputs_fn_service</code>.<br> <li> Included <code>build_inputs_fn_service</code> in the benchmark group.<br>


</details>


  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/136/files#diff-cb8a7335575d6cbd9d8f395a7ba5a19c86e50aeb6c4084a156803a5fcb4a4a77">+17/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.rs</strong><dd><code>Make `nameko_utils` module public for benchmarking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

girolle/src/lib.rs

- Made `nameko_utils` module public for benchmarking purposes.



</details>


  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/136/files#diff-df51b0b24fbb629077ebc369346fae19e9b27be8c799d416dfc3bb3e747d3cde">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>mod.rs</strong><dd><code>Refactor and make `build_inputs_fn_service` public</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

girolle/src/nameko_utils/mod.rs

<li>Refactored <code>push_values_to_result</code> function for cleaner slicing and <br>iteration.<br> <li> Made <code>build_inputs_fn_service</code> function public.<br> <li> Simplified logic in <code>build_inputs_fn_service</code> for checking argument <br>sizes.<br>


</details>


  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/136/files#diff-6ca6455bb90f53eb0ef288bb592ce44e91fda2f73de6f8953280817497cd9000">+25/-29</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

