### PR TITLE
chore: Update directory location for cargo package manifests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,6 @@
 version: 2
 updates:
   - package-ecosystem: "cargo" # See documentation for possible values
-    directory: "/" # Location of package manifests
+    directory: "girolle/" # Location of package manifests
     schedule:
       interval: "weekly"


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Updated the directory location for cargo package manifests in the Dependabot configuration file.
- Changed the `directory` field for the `cargo` package-ecosystem from root (`/`) to `girolle/`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Update directory location for cargo package manifests</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<li>Updated the directory location for cargo package manifests from root <br>to <code>girolle/</code><br> <li> Modified the <code>directory</code> field under <code>package-ecosystem: "cargo"</code><br>


</details>


  </td>
  <td><a href="https://github.com/doubleailes/girolle/pull/139/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

