### PR TITLE
chore: Use the idiomatic way of create a default for Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In this example:
 ### Create a configuration by hand
 
 ```rust
-let conf = Config::default_config();
+let conf = Config::default();
 conf.with_amqp_uri("amqp://toto:super@localhost:5672/")
     .with_rpc_exchange("nameko-rpc")
     .with_max_workers(10)

--- a/docs/content/docs/getting-started/quick-start.md
+++ b/docs/content/docs/getting-started/quick-start.md
@@ -46,7 +46,7 @@ In this example:
 ### Create a configuration by hand
 
 ```rust
-let conf = Config::default_config();
+let conf = Config::default();
 conf.with_amqp_uri("amqp://toto:super@localhost:5672/")
     .with_rpc_exchange("nameko-rpc")
     .with_max_workers(10)

--- a/girolle/src/config.rs
+++ b/girolle/src/config.rs
@@ -59,7 +59,7 @@ pub struct Config {
     persistent: Option<u8>,
 }
 
-impl Config {
+impl Default for Config {
     /// # Create a default config
     ///
     /// This function creates a default configuration.
@@ -67,7 +67,7 @@ impl Config {
     /// ## Returns
     ///
     /// A Config that holds the default configuration.
-    pub fn default_config() -> Self {
+    fn default() -> Self {
         Self {
             AMQP_URI: Some("amqp://guest:guest@localhost/".to_string()),
             web_server_address: Some("".to_string()),
@@ -97,7 +97,9 @@ impl Config {
             persistent: Some(2),
         }
     }
+}
 
+impl Config {
     /// # with_yaml_defaults
     ///
     /// ## Description
@@ -113,7 +115,7 @@ impl Config {
         file.read_to_string(&mut contents)?;
         contents = expand_var(&contents).to_string();
         let overrides: Config = serde_yaml::from_str(&contents)?;
-        Ok(Config::default_config().merge(overrides))
+        Ok(Config::default().merge(overrides))
     }
 
     /// # merge
@@ -325,7 +327,7 @@ fn test_expand_var() {
 
 #[test]
 fn test_config_default() {
-    let config = Config::default_config();
+    let config = Config::default();
     assert_eq!(config.AMQP_URI(), "amqp://guest:guest@localhost/");
     assert_eq!(config.prefetch_count(), 10);
 }

--- a/girolle/src/lib.rs
+++ b/girolle/src/lib.rs
@@ -40,7 +40,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!    let mut rpc_client = RpcClient::new(Config::default_config());
+//!    let mut rpc_client = RpcClient::new(Config::default());
 //!    rpc_client.register_service("video");
 //!    
 //!    let result = rpc_client.send("video", "hello", Payload::new().arg("Girolle")).unwrap();

--- a/girolle/src/rpc_client.rs
+++ b/girolle/src/rpc_client.rs
@@ -35,7 +35,7 @@ use uuid::Uuid;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///    let rpc_client = RpcClient::new(Config::default_config());
+///    let rpc_client = RpcClient::new(Config::default());
 /// }
 pub struct RpcClient {
     conf: Config,
@@ -68,7 +68,7 @@ impl RpcClient {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///   let target_service = RpcClient::new(Config::default_config());
+    ///   let target_service = RpcClient::new(Config::default());
     /// }
     pub fn new(conf: Config) -> Self {
         let identifier = Uuid::new_v4();
@@ -107,7 +107,7 @@ impl RpcClient {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///    let mut rpc_client = RpcClient::new(Config::default_config());
+    ///    let mut rpc_client = RpcClient::new(Config::default());
     ///    rpc_client.start().await.expect("call");
     /// }
     pub async fn start(&mut self) -> GirolleResult<()> {
@@ -170,7 +170,7 @@ impl RpcClient {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let rpc_client = RpcClient::new(Config::default_config());
+    ///     let rpc_client = RpcClient::new(Config::default());
     ///     let identifier = rpc_client.get_identifier();
     /// }
     pub fn get_identifier(&self) -> String {
@@ -372,7 +372,7 @@ impl RpcClient {
     /// use girolle::prelude::*;
     ///
     ///
-    /// let rpc_client = RpcClient::new(Config::default_config());
+    /// let rpc_client = RpcClient::new(Config::default());
     /// let conf = rpc_client.get_config();
     /// ```
     pub fn get_config(&self) -> &Config {
@@ -394,8 +394,8 @@ impl RpcClient {
     /// use girolle::prelude::*;
     ///
     ///
-    /// let mut rpc_client = RpcClient::new(Config::default_config());
-    /// let conf = Config::default_config();
+    /// let mut rpc_client = RpcClient::new(Config::default());
+    /// let conf = Config::default();
     /// rpc_client.set_config(conf);
     /// ```
     pub fn set_config(&mut self, config: Config) -> std::result::Result<(), std::string::String> {
@@ -423,7 +423,7 @@ impl RpcClient {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///    let mut rpc_client = RpcClient::new(Config::default_config());
+    ///    let mut rpc_client = RpcClient::new(Config::default());
     ///    rpc_client.register_service("video").await.expect("call");
     /// }
     pub async fn register_service(&mut self, service_name: &str) -> Result<(), lapin::Error> {
@@ -459,7 +459,7 @@ impl RpcClient {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///    let mut rpc_client = RpcClient::new(Config::default_config());
+    ///    let mut rpc_client = RpcClient::new(Config::default());
     ///    rpc_client.register_service("video").await.expect("call");
     ///    rpc_client.unregister_service("video").expect("call");
     /// }
@@ -482,7 +482,7 @@ impl RpcClient {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///   let rpc_client = RpcClient::new(Config::default_config());
+    ///   let rpc_client = RpcClient::new(Config::default());
     ///   rpc_client.close().await.expect("close");
     /// }
     pub async fn close(&self) -> Result<(), lapin::Error> {
@@ -506,7 +506,7 @@ impl RpcClient {
 ///
 /// #[tokio::main]
 /// async fn main() {
-///      let mut rpc_client = RpcClient::new(Config::default_config());
+///      let mut rpc_client = RpcClient::new(Config::default());
 ///      rpc_client.register_service("video").await.expect("call");
 /// }
 struct TargetService {

--- a/girolle/src/rpc_service.rs
+++ b/girolle/src/rpc_service.rs
@@ -30,7 +30,7 @@ use uuid::Uuid;
 /// }
 ///
 /// fn main() {
-///     let mut services: RpcService = RpcService::new(Config::default_config(),"video");
+///     let mut services: RpcService = RpcService::new(Config::default(),"video");
 ///     services.register(hello).start();
 /// }
 pub struct RpcService {
@@ -60,7 +60,7 @@ impl RpcService {
     /// use girolle::prelude::*;
     ///
     ///
-    /// let services: RpcService = RpcService::new(Config::default_config(),"video");
+    /// let services: RpcService = RpcService::new(Config::default(),"video");
     /// ```
     pub fn new(conf: Config, service_name: &'static str) -> Self {
         Self {
@@ -85,7 +85,7 @@ impl RpcService {
     /// use girolle::prelude::*;
     ///
     ///
-    /// let mut services: RpcService = RpcService::new(Config::default_config(),"video");
+    /// let mut services: RpcService = RpcService::new(Config::default(),"video");
     /// services.set_service_name("other".to_string());
     /// ```
     pub fn set_service_name(&mut self, service_name: String) {
@@ -114,7 +114,7 @@ impl RpcService {
     /// }
     ///
     /// fn main() {
-    ///   let mut services: RpcService = RpcService::new(Config::default_config(),"video");
+    ///   let mut services: RpcService = RpcService::new(Config::default(),"video");
     ///   services.register(hello);
     /// }
     pub fn register(mut self, fn_macro: fn() -> RpcTask) -> Self {
@@ -143,7 +143,7 @@ impl RpcService {
     /// }
     ///
     /// fn main() {
-    ///    let mut services: RpcService = RpcService::new(Config::default_config(),"video");
+    ///    let mut services: RpcService = RpcService::new(Config::default(),"video");
     ///    services.register(hello).start();
     /// }
     pub fn start(&self) -> Result<(), GirolleError> {
@@ -171,7 +171,7 @@ impl RpcService {
     /// }
     ///
     /// fn main() {
-    ///    let mut services: RpcService = RpcService::new(Config::default_config(),"video");
+    ///    let mut services: RpcService = RpcService::new(Config::default(),"video");
     ///    let routing_keys = services.register(hello).get_routing_keys();
     /// }
     pub fn get_routing_keys(&self) -> Vec<String> {
@@ -189,7 +189,7 @@ impl RpcService {
     /// use girolle::prelude::*;
     ///
     ///
-    /// let services: RpcService = RpcService::new(Config::default_config(),"video");
+    /// let services: RpcService = RpcService::new(Config::default(),"video");
     /// let conf = services.get_config();
     /// println!("{}", conf.AMQP_URI());
     /// ```
@@ -212,8 +212,8 @@ impl RpcService {
     /// use girolle::prelude::*;
     ///
     ///
-    /// let mut services: RpcService = RpcService::new(Config::default_config(),"video");
-    /// let conf = Config::default_config();
+    /// let mut services: RpcService = RpcService::new(Config::default(),"video");
+    /// let conf = Config::default();
     /// services.set_config(conf);
     /// ```
     pub fn set_config(&mut self, config: Config) -> std::result::Result<(), std::string::String> {

--- a/girolle/src/rpc_task.rs
+++ b/girolle/src/rpc_task.rs
@@ -21,7 +21,7 @@ use crate::types::NamekoFunction;
 ///  
 ///
 /// fn main() {
-///     let mut services: RpcService = RpcService::new(Config::default_config(),"video");
+///     let mut services: RpcService = RpcService::new(Config::default(),"video");
 ///     let rpc_task = RpcTask::new("hello", vec!["s"], hello);
 /// }
 ///
@@ -61,7 +61,7 @@ impl RpcTask {
     /// }
     ///
     /// fn main() {
-    ///     let mut services: RpcService = RpcService::new(Config::default_config(),"video");
+    ///     let mut services: RpcService = RpcService::new(Config::default(),"video");
     ///     let rpc_task = RpcTask::new("hello", vec!["s"], hello);
     /// }
     ///


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Refactored `Config` to implement Rust's `Default` trait idiomatically
  - Moved default config logic from `default_config()` to `Default::default()`
  - Updated all usages from `Config::default_config()` to `Config::default()`

- Updated documentation and code examples to use `Config::default()`

- Adjusted tests to use the new default config instantiation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>config.rs</strong><dd><code>Refactor Config to implement Default trait idiomatically</code>&nbsp; </dd></td>
  <td><a href="https://github.com/doubleailes/girolle/pull/150/files#diff-267236f6f094fb701ce45164eaffcc11ceda141e9282ccc29fb6c0df021dd8fa">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>lib.rs</strong><dd><code>Update code examples to use Config::default()</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/doubleailes/girolle/pull/150/files#diff-df51b0b24fbb629077ebc369346fae19e9b27be8c799d416dfc3bb3e747d3cde">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rpc_client.rs</strong><dd><code>Update RpcClient docs and code to use Config::default()</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/doubleailes/girolle/pull/150/files#diff-a9fe91e540be452dba08af8646f6d3ab4453ab253a7791cb7db45bbdf0729aa9">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>rpc_service.rs</strong><dd><code>Update RpcService docs and code to use Config::default()</code>&nbsp; </dd></td>
  <td><a href="https://github.com/doubleailes/girolle/pull/150/files#diff-905fc53bd11f000b1d04f3652165202c7e78c765664736b6908058150c364ed2">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rpc_task.rs</strong><dd><code>Update RpcTask docs to use Config::default()</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/doubleailes/girolle/pull/150/files#diff-7f0a194b3990b62f6666f21d3345f176f1d72f89023ba3ece56704beafc2065d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Update README config example to use Config::default()</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/doubleailes/girolle/pull/150/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>quick-start.md</strong><dd><code>Update quick start guide to use Config::default()</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/doubleailes/girolle/pull/150/files#diff-c3545e2e04c1614dc4e8537612a758273b781b3d986a0b1e0f6721a9f11a44ff">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>