### PR TITLE
feat: Introduce async handler model with RpcContext

### DIFF
--- a/examples/src/simple_service.rs
+++ b/examples/src/simple_service.rs
@@ -1,16 +1,16 @@
-use std::vec;
-
 use girolle::prelude::*;
-
-fn hello_core(s: &[Value]) -> GirolleResult<Value> {
-    // Parse the incomming data
-    let n: String = serde_json::from_value(s[0].clone())?;
-    let hello_str: Value = format!("Hello, {}!, by Girolle", n).into();
-    Ok(hello_str)
-}
+use std::sync::Arc;
 
 fn hello() -> RpcTask {
-    RpcTask::new("hello", vec!["s"], hello_core)
+    RpcTask::new(
+        "hello",
+        Arc::new(|_ctx: RpcContext, payload: Payload| -> BoxFuture<GirolleResult<Value>> {
+            Box::pin(async move {
+                let n: String = serde_json::from_value(payload.args()[0].clone())?;
+                Ok(serde_json::to_value(format!("Hello, {}!, by Girolle", n))?)
+            })
+        }),
+    )
 }
 
 fn fast_fibonacci(n: u64) -> u64 {
@@ -30,14 +30,16 @@ fn fast_fibonacci(n: u64) -> u64 {
     }
 }
 
-fn fibonacci_reccursive(s: &[Value]) -> GirolleResult<Value> {
-    let n: u64 = serde_json::from_value(s[0].clone())?;
-    let result: Value = serde_json::to_value(fast_fibonacci(n))?;
-    Ok(result)
-}
-
 fn fibonacci() -> RpcTask {
-    RpcTask::new("fibonacci", vec!["n"], fibonacci_reccursive)
+    RpcTask::new(
+        "fibonacci",
+        Arc::new(|_ctx: RpcContext, payload: Payload| -> BoxFuture<GirolleResult<Value>> {
+            Box::pin(async move {
+                let n: u64 = serde_json::from_value(payload.args()[0].clone())?;
+                Ok(serde_json::to_value(fast_fibonacci(n))?)
+            })
+        }),
+    )
 }
 
 fn main() {
@@ -45,7 +47,7 @@ fn main() {
     let conf: Config = Config::with_yaml_defaults("staging/config.yml".to_string()).unwrap();
     // Create the rpc service struct
     let services: RpcService = RpcService::new(conf, "video");
-    // Add the method with the register ans start the service because
+    // Add the method with the register and start the service because
     // register return the service
     let _ = services.register(hello).register(fibonacci).start();
 }

--- a/girolle/src/lib.rs
+++ b/girolle/src/lib.rs
@@ -65,3 +65,4 @@ pub use serde_json;
 pub use serde_json::{json, Value};
 mod error;
 pub use error::GirolleError;
+pub use types::{BoxFuture, EventDispatcher, GirolleResult, RpcCaller, RpcContext, RpcHandler};

--- a/girolle/src/nameko_utils.rs
+++ b/girolle/src/nameko_utils.rs
@@ -1,6 +1,7 @@
 use crate::error::GirolleError;
 use crate::payload::{Payload, PayloadResult};
 use crate::rpc_task::RpcTask;
+use crate::types::RpcContext;
 use lapin::options::BasicPublishOptions;
 /// # nameko_utils
 ///
@@ -256,25 +257,10 @@ pub(crate) async fn compute_deliver(
     rpc_channel: &Channel,
     rpc_exchange: &str,
     reply_to_id: String,
+    ctx: RpcContext,
 ) {
-    // Publish the response
-    let fn_service = rpc_task_struct.inner_function;
-    let buildted_args = match build_inputs_fn_service(&rpc_task_struct.args, incomming_data) {
-        Ok(result) => result,
-        Err(error) => {
-            publish(
-                rpc_channel,
-                PayloadResult::from_error(error.convert()),
-                properties,
-                reply_to_id,
-                rpc_exchange,
-            )
-            .await
-            .expect("Error publishing");
-            return;
-        }
-    };
-    match fn_service(&buildted_args) {
+    let handler = rpc_task_struct.handler.clone();
+    match handler(ctx, incomming_data).await {
         Ok(result) => {
             publish(
                 rpc_channel,

--- a/girolle/src/payload.rs
+++ b/girolle/src/payload.rs
@@ -128,6 +128,18 @@ impl Payload {
     pub fn is_empty(&self) -> bool {
         self.args.is_empty() && self.kwargs.is_empty()
     }
+    /// # args
+    ///
+    /// Borrow the positional arguments carried by this payload.
+    pub fn args(&self) -> &[Value] {
+        &self.args
+    }
+    /// # kwargs
+    ///
+    /// Borrow the keyword arguments carried by this payload.
+    pub fn kwargs(&self) -> &HashMap<String, Value> {
+        &self.kwargs
+    }
 }
 
 impl fmt::Display for Payload {

--- a/girolle/src/prelude.rs
+++ b/girolle/src/prelude.rs
@@ -4,7 +4,7 @@ pub use crate::payload::Payload;
 pub use crate::rpc_client::{RpcClient, RpcReply, RpcResult};
 pub use crate::rpc_service::RpcService;
 pub use crate::rpc_task::RpcTask;
-pub use crate::types::{GirolleResult, NamekoFunction};
+pub use crate::types::{BoxFuture, EventDispatcher, GirolleResult, RpcCaller, RpcContext, RpcHandler};
 pub use girolle_macro::girolle;
 pub use serde_json;
 pub use serde_json::{json, Value};

--- a/girolle/src/rpc_service.rs
+++ b/girolle/src/rpc_service.rs
@@ -5,6 +5,7 @@ use crate::{
     payload::{Payload, PayloadResult},
     queue::{create_service_channel, get_connection},
     rpc_task::RpcTask,
+    types::{EventDispatcher, RpcCaller, RpcContext},
 };
 use lapin::{message::DeliveryResult, options::*, types::FieldTable, Channel};
 use std::{collections::HashMap, sync::Arc};
@@ -229,6 +230,8 @@ struct SharedData {
     service_name: String,
     semaphore: Semaphore,
     parent_calls_tracked: usize,
+    rpc_caller: RpcCaller,
+    event_dispatcher: EventDispatcher,
 }
 
 /// # rpc_service
@@ -285,6 +288,8 @@ async fn rpc_service(
         service_name: service_name.to_string(),
         semaphore: Semaphore::new(conf.max_workers() as usize),
         parent_calls_tracked: conf.parent_calls_tracked() as usize,
+        rpc_caller: RpcCaller::placeholder(),
+        event_dispatcher: EventDispatcher::placeholder(),
     });
     consumer.set_delegate(move |delivery: DeliveryResult| {
         let shared_data = Arc::clone(&shared_data);
@@ -304,6 +309,12 @@ async fn rpc_service(
 
             let opt_routing_key = delivery.routing_key.to_string();
             let reply_to_id = get_id(delivery.properties.reply_to(), "reply_to_id");
+            let correlation_id = get_id(delivery.properties.correlation_id(), "correlation_id");
+            let inbound_headers = delivery
+                .properties
+                .headers()
+                .clone()
+                .unwrap_or_default();
             let properties = delivery_to_message_properties(
                 &delivery,
                 &id,
@@ -320,6 +331,15 @@ async fn rpc_service(
                 (Some(rpc_task_struct), _) => {
                     let incomming_data: Payload = serde_json::from_slice(&delivery.data)
                         .expect("Can't deserialize incomming data");
+                    let ctx = RpcContext {
+                        service_name: incommig_service.to_string(),
+                        method_name: incomming_method.to_string(),
+                        correlation_id: correlation_id.clone(),
+                        reply_to: reply_to_id.clone(),
+                        headers: inbound_headers,
+                        rpc: shared_data.rpc_caller.clone(),
+                        events: shared_data.event_dispatcher.clone(),
+                    };
                     compute_deliver(
                         incomming_data,
                         properties,
@@ -327,6 +347,7 @@ async fn rpc_service(
                         &shared_data.rpc_channel,
                         &shared_data.rpc_exchange,
                         reply_to_id,
+                        ctx,
                     )
                     .await
                 }

--- a/girolle/src/rpc_task.rs
+++ b/girolle/src/rpc_task.rs
@@ -1,79 +1,57 @@
-use crate::types::NamekoFunction;
+use crate::types::RpcHandler;
+
 /// # RpcTask
 ///
 /// ## Description
 ///
-/// This struct is used to create a RPC task. This task will be used to register
-/// a function in the RpcService struct.
+/// A single registerable RPC method. Wraps an async [`RpcHandler`] together
+/// with the method name it should be exposed under.
+///
+/// Most users construct an `RpcTask` indirectly via the [`#[girolle]`](girolle_macro::girolle)
+/// attribute macro. The macro generates a constructor function returning
+/// `RpcTask`, which is then passed to [`RpcService::register`](crate::RpcService::register).
+///
+/// Handlers built by hand can use [`RpcTask::new`] directly.
 ///
 /// ## Example
 ///
 /// ```rust,no_run
 /// use girolle::prelude::*;
-/// use std::vec;
+/// use std::sync::Arc;
 ///
-/// fn hello(s: &[Value]) -> GirolleResult<Value> {
-///    // Parse the incomming data
-///    let n: String = serde_json::from_value(s[0].clone())?;
-///    let hello_str: Value = format!("Hello, {}!, by Girolle", n).into();
-///    Ok(hello_str)
+/// fn hello() -> RpcTask {
+///     RpcTask::new(
+///         "hello",
+///         Arc::new(|_ctx, payload| {
+///             Box::pin(async move {
+///                 let n: String = serde_json::from_value(payload.args()[0].clone())?;
+///                 Ok(serde_json::to_value(format!("Hello, {}!", n))?)
+///             })
+///         }),
+///     )
 /// }
-///  
 ///
 /// fn main() {
-///     let mut services: RpcService = RpcService::new(Config::default(),"video");
-///     let rpc_task = RpcTask::new("hello", vec!["s"], hello);
+///     let _services: RpcService = RpcService::new(Config::default(), "video")
+///         .register(hello);
 /// }
-///
+/// ```
 #[derive(Clone)]
 pub struct RpcTask {
     pub name: &'static str,
-    pub args: Vec<&'static str>,
-    pub inner_function: NamekoFunction,
+    pub handler: RpcHandler,
 }
+
 impl RpcTask {
     /// # new
     ///
-    /// ## Description
-    ///
-    /// This function create a new RpcTask struct
+    /// Create a new `RpcTask` from a method name and an [`RpcHandler`].
     ///
     /// ## Arguments
     ///
-    /// * `name` - The name of the function to call
-    /// * `inner_function` - The function to call as NamekoFunction
-    ///
-    /// ## Returns
-    ///
-    /// This function return a girolle::RpcTask struct
-    ///
-    /// ## Example
-    ///
-    /// ```rust,no_run
-    /// use girolle::prelude::*;
-    /// use std::vec;
-    ///
-    /// fn hello(s: &[Value]) -> GirolleResult<Value> {
-    ///    // Parse the incomming data
-    ///    let n: String = serde_json::from_value(s[0].clone())?;
-    ///    let hello_str: Value = format!("Hello, {}!, by Girolle", n).into();
-    ///    Ok(hello_str)
-    /// }
-    ///
-    /// fn main() {
-    ///     let mut services: RpcService = RpcService::new(Config::default(),"video");
-    ///     let rpc_task = RpcTask::new("hello", vec!["s"], hello);
-    /// }
-    ///
-    pub fn new(
-        name: &'static str,
-        args: Vec<&'static str>,
-        inner_function: NamekoFunction,
-    ) -> Self {
-        Self {
-            name,
-            args,
-            inner_function,
-        }
+    /// * `name` — the RPC method name (the routing key suffix)
+    /// * `handler` — the async handler invoked for each inbound delivery
+    pub fn new(name: &'static str, handler: RpcHandler) -> Self {
+        Self { name, handler }
     }
 }

--- a/girolle/src/types.rs
+++ b/girolle/src/types.rs
@@ -1,17 +1,78 @@
 use crate::error::GirolleError;
-use serde_json;
+use crate::payload::Payload;
+use lapin::types::FieldTable;
 use serde_json::Value;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
 
-/// # Result
+/// # GirolleResult
 ///
-/// ## Description
-///
-/// This type is used to return a `Result<Value>` in the RPC call
+/// Standard result alias used throughout the crate.
 pub type GirolleResult<T> = std::result::Result<T, GirolleError>;
-/// # NamekoFunction
+
+/// # BoxFuture
 ///
-/// ## Description
+/// Boxed, dynamically-dispatched future returned by an [`RpcHandler`].
+pub type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+
+/// # RpcCaller
 ///
-/// This type is used to define the function to call in the RPC service it
-/// mainly simplify the code to manipulate a complexe type.
-pub type NamekoFunction = fn(&[Value]) -> GirolleResult<Value>;
+/// Capability handle exposed on [`RpcContext`] that lets a service handler
+/// call other services as an RPC client.
+///
+/// In this release the caller is a placeholder; the in-service async RPC
+/// core (shared reply queue, correlation map) lands in a follow-up change.
+#[derive(Clone, Debug, Default)]
+pub struct RpcCaller {
+    _private: (),
+}
+
+impl RpcCaller {
+    pub(crate) fn placeholder() -> Self {
+        Self { _private: () }
+    }
+}
+
+/// # EventDispatcher
+///
+/// Capability handle exposed on [`RpcContext`] that lets a service handler
+/// emit Nameko-compatible events.
+///
+/// In this release the dispatcher is a placeholder; the publisher
+/// implementation lands in a follow-up change.
+#[derive(Clone, Debug, Default)]
+pub struct EventDispatcher {
+    _private: (),
+}
+
+impl EventDispatcher {
+    pub(crate) fn placeholder() -> Self {
+        Self { _private: () }
+    }
+}
+
+/// # RpcContext
+///
+/// Per-delivery context handed to every [`RpcHandler`]. Holds inbound AMQP
+/// metadata and the capability handles a handler can use to call other
+/// services or emit events.
+#[derive(Clone, Debug)]
+pub struct RpcContext {
+    pub service_name: String,
+    pub method_name: String,
+    pub correlation_id: String,
+    pub reply_to: String,
+    pub headers: FieldTable,
+    pub rpc: RpcCaller,
+    pub events: EventDispatcher,
+}
+
+/// # RpcHandler
+///
+/// Async handler signature stored on an [`RpcTask`](crate::RpcTask).
+///
+/// The handler receives the per-delivery [`RpcContext`] and the decoded
+/// [`Payload`] and returns a future resolving to the handler's JSON result.
+pub type RpcHandler =
+    Arc<dyn Fn(RpcContext, Payload) -> BoxFuture<GirolleResult<Value>> + Send + Sync>;

--- a/girolle_macro/src/entry.rs
+++ b/girolle_macro/src/entry.rs
@@ -2,113 +2,116 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::fold::Fold;
 use syn::parse_quote;
-use syn::{parse2, FnArg, ItemFn};
+use syn::{parse2, FnArg, ItemFn, Pat, Stmt};
 
-struct Task {
-    name: syn::Ident,
-    args: Vec<FnArg>,
-    deser_wrapper: Vec<syn::Stmt>,
-    args_input_core: Vec<syn::Pat>,
-}
-impl Task {
-    fn new(name: syn::Ident) -> Self {
-        Task {
-            name,
-            args: Vec::new(),
-            deser_wrapper: Vec::new(),
-            args_input_core: Vec::new(),
-        }
-    }
-    /// # add_input_serialize
-    ///
-    /// ## Description
-    ///
-    /// This function is used to add the input serialization to the task.
-    /// It use for the second function to deserialize the input.
-    ///
-    /// ## Arguments
-    ///
-    /// - `self` : &mut Task : The task to modify.
-    fn add_input_serialize(&mut self) {
-        let mut stmts: Vec<syn::Stmt> = Vec::new();
-        for (i, arg) in self.args.iter().enumerate() {
-            let data_quote = quote! {
-                data[#i]
-            };
-            if let FnArg::Typed(pat_type) = arg {
-                let pat = &pat_type.pat;
-                let ty = &pat_type.ty;
-                self.args_input_core.push(*pat.clone());
-                stmts.push(
-                    parse_quote! {let #pat: #ty = serde_json::from_value(#data_quote.clone())?;},
-                );
-            }
-        }
-        self.deser_wrapper.clone_from(&stmts);
-    }
+/// Renames the user-written function's identifier to `<name>_core`, both at
+/// the definition site and at any recursive call site inside the body.
+struct CoreRenamer {
+    from: syn::Ident,
 }
 
-impl Fold for Task {
-    /// # fold_ident
-    ///
-    /// ## Description
-    ///
-    /// This function is used to fold the ident of the function by replacing the
-    /// original name by the name suffixed by `_core`.
-    ///
-    /// ## Arguments
-    ///
-    /// - `i` : proc_macro2::Ident : The ident to fold.
-    ///
-    /// ## Returns
-    ///
-    /// - `proc_macro2::Ident` : The folded ident.
+impl Fold for CoreRenamer {
     fn fold_ident(&mut self, i: proc_macro2::Ident) -> proc_macro2::Ident {
-        let folded_item = i.clone();
-        // Capture the original statements
-        if folded_item == self.name {
-            return syn::Ident::new(
-                &format!("{}_core", folded_item),
+        if i == self.from {
+            syn::Ident::new(
+                &format!("{}_core", i),
                 proc_macro2::Span::call_site(),
-            );
+            )
+        } else {
+            i
         }
-        folded_item
+    }
+}
+
+/// Returns true if the FnArg is a typed argument whose type path ends in
+/// `RpcContext`. We use this to detect the optional first context arg.
+fn is_ctx_arg(arg: &FnArg) -> bool {
+    match arg {
+        FnArg::Typed(pt) => match &*pt.ty {
+            syn::Type::Path(tp) => tp
+                .path
+                .segments
+                .last()
+                .map(|s| s.ident == "RpcContext")
+                .unwrap_or(false),
+            _ => false,
+        },
+        _ => false,
     }
 }
 
 pub(crate) fn girolle_task(input: TokenStream) -> TokenStream {
-    let item_fn = parse2::<ItemFn>(input).unwrap();
+    let item_fn = parse2::<ItemFn>(input).expect("girolle: expected a free function");
     let name = item_fn.sig.ident.clone();
-    let mut task = Task::new(name.clone());
-    task.args = item_fn.sig.inputs.iter().cloned().collect();
-    let new_item_fn = task.fold_item_fn(item_fn);
-    task.add_input_serialize();
-    let args_str: Vec<String> = task
-        .args
-        .iter()
-        .map(|arg| match arg {
-            FnArg::Typed(pat_type) => {
-                let pat = &pat_type.pat;
-                quote! {#pat}.to_string()
-            }
-            _ => "".to_string(),
-        })
-        .collect();
-    let name_fn = quote! {#name}.to_string();
-    let fn_wrap_name = syn::Ident::new(&format!("{}_wrap", name), proc_macro2::Span::call_site());
-    let fn_core_name: syn::Ident =
-        syn::Ident::new(&format!("{}_core", name), proc_macro2::Span::call_site());
-    let wrap = task.deser_wrapper;
-    let args_input_core: Vec<syn::Pat> = task.args_input_core.clone();
-    let expanded = quote! {
-        #new_item_fn
-        fn #fn_wrap_name(data : & [Value]) -> GirolleResult<Value>{
-            #(#wrap)*
-            Ok(serde_json :: to_value(#fn_core_name(#(#args_input_core),*)) ?)
-        }
-        fn #name() -> girolle::RpcTask {
-            girolle::RpcTask::new(#name_fn,vec![#(#args_str),*], #fn_wrap_name)
-        }
+    let is_async = item_fn.sig.asyncness.is_some();
+
+    let inputs: Vec<FnArg> = item_fn.sig.inputs.iter().cloned().collect();
+    let (has_ctx, real_args): (bool, Vec<FnArg>) = match inputs.first() {
+        Some(first) if is_ctx_arg(first) => (true, inputs[1..].to_vec()),
+        _ => (false, inputs),
     };
-    expanded
+
+    // Rename the original function to `<name>_core`.
+    let mut renamer = CoreRenamer { from: name.clone() };
+    let new_item_fn = renamer.fold_item_fn(item_fn);
+
+    // Build the per-arg name list used for kwargs->args dispatch and the
+    // deserialization statements unpacking each arg from the Payload.
+    let mut args_str: Vec<String> = Vec::new();
+    let mut deser_stmts: Vec<Stmt> = Vec::new();
+    let mut args_input_core: Vec<Pat> = Vec::new();
+    for (i, arg) in real_args.iter().enumerate() {
+        if let FnArg::Typed(pat_type) = arg {
+            let pat = &pat_type.pat;
+            let ty = &pat_type.ty;
+            args_str.push(quote! { #pat }.to_string());
+            args_input_core.push(*pat.clone());
+            deser_stmts.push(parse_quote! {
+                let #pat: #ty = ::girolle::serde_json::from_value(__args[#i].clone())?;
+            });
+        }
+    }
+
+    let name_fn = quote! { #name }.to_string();
+    let fn_core_name =
+        syn::Ident::new(&format!("{}_core", name), proc_macro2::Span::call_site());
+
+    let core_call = match (has_ctx, is_async) {
+        (true, true) => quote! { #fn_core_name(__ctx, #(#args_input_core),*).await },
+        (true, false) => quote! { #fn_core_name(__ctx, #(#args_input_core),*) },
+        (false, true) => quote! { #fn_core_name(#(#args_input_core),*).await },
+        (false, false) => quote! { #fn_core_name(#(#args_input_core),*) },
+    };
+
+    let ctx_binding = if has_ctx {
+        quote! { let __ctx = ctx; }
+    } else {
+        quote! { let _ = ctx; }
+    };
+
+    quote! {
+        #new_item_fn
+
+        fn #name() -> ::girolle::RpcTask {
+            ::girolle::RpcTask::new(
+                #name_fn,
+                ::std::sync::Arc::new(
+                    |ctx: ::girolle::RpcContext, payload: ::girolle::Payload|
+                        -> ::girolle::BoxFuture<::girolle::GirolleResult<::girolle::Value>>
+                    {
+                        ::std::boxed::Box::pin(async move {
+                            #ctx_binding
+                            let __args = ::girolle::nameko_utils::build_inputs_fn_service(
+                                &[#(#args_str),*],
+                                payload,
+                            )?;
+                            #(#deser_stmts)*
+                            let __result = #core_call;
+                            Ok(::girolle::serde_json::to_value(__result)?)
+                        })
+                    },
+                ),
+            )
+        }
+    }
 }


### PR DESCRIPTION
Replace the sync `NamekoFunction = fn(&[Value]) -> GirolleResult<Value>` with an async handler:

    Arc<dyn Fn(RpcContext, Payload) -> BoxFuture<GirolleResult<Value>>
        + Send + Sync>

Every RPC delivery now builds an `RpcContext` carrying the routing key parts, correlation id, reply-to, inbound headers, and two capability handles (`RpcCaller`, `EventDispatcher`) that follow-up changes will wire to a shared in-service RPC core and an event publisher. In this change both capabilities are inert placeholders so handlers can be typed against them already.

The `#[girolle]` macro now generates an async wrapper, accepts both `fn` and `async fn` user functions, and detects an optional first `ctx: RpcContext` argument. Kwargs-to-args dispatch moved into the generated wrapper so `RpcTask` no longer needs an `args` list.

`RpcTask::new` and the removal of `NamekoFunction` are breaking; the hand-rolled `examples/src/simple_service.rs` is updated to the new shape.