### PR TITLE
feat: Wire event dispatcher for ctx.events.dispatch

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -46,3 +46,7 @@ path = "src/simple_fib.rs"
 [[example]]
 name = "proxy_service"
 path = "src/proxy_service.rs"
+
+[[example]]
+name = "event_emitter"
+path = "src/event_emitter.rs"

--- a/examples/src/event_emitter.rs
+++ b/examples/src/event_emitter.rs
@@ -1,0 +1,36 @@
+//! Demonstrates emitting Nameko-compatible events from a service handler.
+//!
+//! `users.create_user` returns a greeting and emits a `user_created` event
+//! on the `users.events` topic exchange.
+//!
+//! ```sh
+//! cargo run --example event_emitter
+//! ```
+//!
+//! On the consumer side any Nameko (or Girolle) subscriber bound to
+//! `users.events` with routing key `user_created` will receive the event.
+
+use girolle::prelude::*;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct UserCreated {
+    name: String,
+}
+
+#[girolle]
+async fn create_user(ctx: RpcContext, name: String) -> String {
+    let payload = UserCreated { name: name.clone() };
+    ctx.events
+        .dispatch("users", "user_created", &payload)
+        .await
+        .expect("event dispatch failed");
+    format!("User {} created", name)
+}
+
+fn main() {
+    let conf: Config = Config::with_yaml_defaults("staging/config.yml".to_string()).unwrap();
+    let _ = RpcService::new(conf, "users")
+        .register(create_user)
+        .start();
+}

--- a/girolle/src/events.rs
+++ b/girolle/src/events.rs
@@ -1,0 +1,102 @@
+//! In-service event dispatcher.
+//!
+//! [`EventDispatcherCore`] holds the per-service state required to publish
+//! Nameko-compatible events: a publish channel and a cache of topic
+//! exchanges already declared on the broker. Exchanges follow the
+//! `{source_service}.events` convention and are declared lazily the first
+//! time a given source emits.
+//!
+//! Constructed once in [`crate::rpc_service`] startup and shared (via
+//! `Arc`) by every inbound delivery's [`crate::types::EventDispatcher`].
+
+use crate::config::Config;
+use crate::error::GirolleError;
+use crate::types::GirolleResult;
+use dashmap::DashSet;
+use lapin::options::{BasicPublishOptions, ExchangeDeclareOptions};
+use lapin::types::{AMQPValue, FieldTable, ShortString};
+use lapin::{BasicProperties, Connection, ExchangeKind};
+use std::sync::Arc;
+use uuid::Uuid;
+
+const NAMEKO_AMQP_URI: &str = "nameko.AMQP_URI";
+
+pub(crate) struct EventDispatcherCore {
+    publish_channel: lapin::Channel,
+    declared_exchanges: DashSet<String>,
+    amqp_uri: String,
+    #[allow(dead_code)]
+    identifier: String,
+}
+
+impl EventDispatcherCore {
+    pub(crate) async fn new(
+        conn: &Connection,
+        conf: &Config,
+        identifier: Uuid,
+    ) -> GirolleResult<Arc<Self>> {
+        let publish_channel = conn.create_channel().await?;
+        Ok(Arc::new(Self {
+            publish_channel,
+            declared_exchanges: DashSet::new(),
+            amqp_uri: conf.AMQP_URI().to_string(),
+            identifier: identifier.to_string(),
+        }))
+    }
+
+    /// Publish a single event.
+    ///
+    /// Lazily declares the `{source_service}.events` durable topic exchange
+    /// the first time a given source emits, then publishes a persistent
+    /// JSON-encoded message with `event_type` as the routing key.
+    pub(crate) async fn dispatch(
+        &self,
+        parent_headers: &FieldTable,
+        source_service: &str,
+        event_type: &str,
+        payload_bytes: Vec<u8>,
+    ) -> GirolleResult<()> {
+        let exchange = format!("{}.events", source_service);
+        if !self.declared_exchanges.contains(&exchange) {
+            self.publish_channel
+                .exchange_declare(
+                    &exchange,
+                    ExchangeKind::Topic,
+                    ExchangeDeclareOptions {
+                        durable: true,
+                        ..Default::default()
+                    },
+                    FieldTable::default(),
+                )
+                .await
+                .map_err(GirolleError::LapinError)?;
+            self.declared_exchanges.insert(exchange.clone());
+        }
+
+        let mut headers = parent_headers.clone();
+        headers.insert(
+            ShortString::from(NAMEKO_AMQP_URI),
+            AMQPValue::LongString(self.amqp_uri.clone().into()),
+        );
+
+        let properties = BasicProperties::default()
+            .with_content_type("application/json".into())
+            .with_content_encoding("utf-8".into())
+            .with_delivery_mode(2)
+            .with_headers(headers)
+            .with_priority(0);
+
+        self.publish_channel
+            .basic_publish(
+                &exchange,
+                event_type,
+                BasicPublishOptions::default(),
+                &payload_bytes,
+                properties,
+            )
+            .await
+            .map_err(GirolleError::LapinError)?;
+
+        Ok(())
+    }
+}

--- a/girolle/src/lib.rs
+++ b/girolle/src/lib.rs
@@ -53,6 +53,7 @@ pub use config::Config;
 // Public for bench purpose
 pub mod nameko_utils;
 pub mod prelude;
+mod events;
 mod rpc_client;
 pub use rpc_client::RpcClient;
 mod rpc_core;

--- a/girolle/src/rpc_service.rs
+++ b/girolle/src/rpc_service.rs
@@ -1,6 +1,7 @@
 use crate::{
     config::Config,
     error::GirolleError,
+    events::EventDispatcherCore,
     nameko_utils::{compute_deliver, delivery_to_message_properties, get_id, publish},
     payload::{Payload, PayloadResult},
     queue::{create_service_channel, get_connection},
@@ -276,6 +277,9 @@ async fn rpc_service(
     // Stand up the in-service RPC core: reply queue, correlation map,
     // and a publish channel used by ctx.rpc.call().
     let rpc_caller_core = RpcCallerCore::new(&conn, conf, id).await?;
+    // Stand up the event-dispatcher core: a publish channel and a cache
+    // of declared `{source}.events` exchanges used by ctx.events.dispatch().
+    let event_dispatcher_core = EventDispatcherCore::new(&conn, conf, id).await?;
     // Start a consumer.
     let consumer = rpc_channel
         .basic_consume(
@@ -293,7 +297,7 @@ async fn rpc_service(
         semaphore: Semaphore::new(conf.max_workers() as usize),
         parent_calls_tracked: conf.parent_calls_tracked() as usize,
         rpc_caller: RpcCaller::from_core(rpc_caller_core),
-        event_dispatcher: EventDispatcher::placeholder(),
+        event_dispatcher: EventDispatcher::from_core(event_dispatcher_core),
     });
     consumer.set_delegate(move |delivery: DeliveryResult| {
         let shared_data = Arc::clone(&shared_data);
@@ -338,6 +342,9 @@ async fn rpc_service(
                     let rpc = shared_data
                         .rpc_caller
                         .with_parent_headers(inbound_headers.clone());
+                    let events = shared_data
+                        .event_dispatcher
+                        .with_parent_headers(inbound_headers.clone());
                     let ctx = RpcContext {
                         service_name: incommig_service.to_string(),
                         method_name: incomming_method.to_string(),
@@ -345,7 +352,7 @@ async fn rpc_service(
                         reply_to: reply_to_id.clone(),
                         headers: inbound_headers,
                         rpc,
-                        events: shared_data.event_dispatcher.clone(),
+                        events,
                     };
                     compute_deliver(
                         incomming_data,

--- a/girolle/src/types.rs
+++ b/girolle/src/types.rs
@@ -1,7 +1,9 @@
 use crate::error::GirolleError;
+use crate::events::EventDispatcherCore;
 use crate::payload::Payload;
 use crate::rpc_core::RpcCallerCore;
 use lapin::types::FieldTable;
+use serde::Serialize;
 use serde_json::Value;
 use std::future::Future;
 use std::pin::Pin;
@@ -85,16 +87,63 @@ impl RpcCaller {
 /// Capability handle exposed on [`RpcContext`] that lets a service handler
 /// emit Nameko-compatible events.
 ///
-/// In this release the dispatcher is a placeholder; the publisher
-/// implementation lands in a follow-up change.
-#[derive(Clone, Debug, Default)]
+/// Each inbound delivery receives an `EventDispatcher` derived from the
+/// service's shared event-dispatcher core. The derivation captures the
+/// parent delivery's AMQP headers so that emitted events carry the
+/// inbound `nameko.call_id_stack` through.
+///
+/// A default-constructed `EventDispatcher` has no underlying core; calling
+/// [`EventDispatcher::dispatch`] on it returns an error. Useful for
+/// unit-testing handlers without standing up a broker.
+#[derive(Clone, Default)]
 pub struct EventDispatcher {
-    _private: (),
+    inner: Option<Arc<EventDispatcherCore>>,
+    parent_headers: FieldTable,
+}
+
+impl std::fmt::Debug for EventDispatcher {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EventDispatcher")
+            .field("active", &self.inner.is_some())
+            .finish()
+    }
 }
 
 impl EventDispatcher {
-    pub(crate) fn placeholder() -> Self {
-        Self { _private: () }
+    pub(crate) fn from_core(core: Arc<EventDispatcherCore>) -> Self {
+        Self {
+            inner: Some(core),
+            parent_headers: FieldTable::default(),
+        }
+    }
+
+    pub(crate) fn with_parent_headers(&self, headers: FieldTable) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            parent_headers: headers,
+        }
+    }
+
+    /// Emit `event_type` on the `{source_service}.events` topic exchange.
+    ///
+    /// `payload` is serialized as JSON. The exchange is declared lazily on
+    /// the first emit per source. Returns when the publish has been handed
+    /// to the broker; delivery is fire-and-forget (no acknowledgement).
+    pub async fn dispatch<T: Serialize>(
+        &self,
+        source_service: &str,
+        event_type: &str,
+        payload: &T,
+    ) -> GirolleResult<()> {
+        let core = self.inner.as_ref().ok_or_else(|| {
+            GirolleError::ServiceMissingError(
+                "EventDispatcher has no in-service core; ctx.events.dispatch requires a running RpcService"
+                    .to_string(),
+            )
+        })?;
+        let body = serde_json::to_vec(payload)?;
+        core.dispatch(&self.parent_headers, source_service, event_type, body)
+            .await
     }
 }
 


### PR DESCRIPTION
## Summary
Closes the third and final piece of the async-handler refactor — events.

- New `girolle/src/events.rs` — `EventDispatcherCore` owns a publish channel and a `DashSet<String>` cache of declared `{source}.events` topic exchanges (`durable: true`). Exchanges are declared lazily the first time a given source emits, so a single dispatcher can fan out events for multiple sources.
- `EventDispatcher` now holds `Option<Arc<EventDispatcherCore>>` plus the parent delivery's `FieldTable`. `pub async fn dispatch<T: Serialize>(source_service, event_type, &payload)` serializes the payload to JSON and publishes with persistent delivery, JSON content-type, and `event_type` as the routing key. `nameko.AMQP_URI` is stamped onto headers and the parent's `nameko.call_id_stack` (when present) is propagated through.
- `RpcService` startup calls `EventDispatcherCore::new(&conn, conf, id)` once and wires the resulting dispatcher into `SharedData`. Per delivery the consumer does `with_parent_headers(inbound_headers.clone())` for both `rpc` and `events`.
- `examples/src/event_emitter.rs` — a service that emits a `user_created` event on `users.events` from inside a handler.

## Acceptance
With this merged, a handler can:
- Receive an `RpcContext` carrying inbound metadata
- Call other services via `ctx.rpc.call(...)`
- Emit Nameko-compatible events via `ctx.events.dispatch(...)`

…which closes out the original async-handler issue's acceptance criteria.

## Known limitations (deferred)
- No publisher confirms — dispatch returns once the publish has been handed to the broker, no broker-side ack.
- Outbound `call_id_stack` propagated as-is from the parent (matches the RPC caller's behavior; see #156).
- No event consumer support yet — that's a separate piece of work.

## Test plan
- [x] \`cargo build --workspace\`
- [x] \`cargo build --examples\` (incl. new \`event_emitter\`)
- [x] \`cargo test --workspace --lib\` (14 passed)
- [x] \`cargo test --workspace --doc\` (30 + 1 passed)
- [x] \`cargo clippy --workspace --all-targets\`
- [ ] Smoke test: run \`event_emitter\`, call \`users.create_user\`, observe a message on \`users.events\` with routing key \`user_created\` (e.g. via the RabbitMQ management UI or a Nameko subscriber).

🤖 Generated with [Claude Code](https://claude.com/claude-code)