### PR TITLE
feat: Add event subscriptions and CLI sender

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 resolver = "2"
 members = ["girolle", "girolle_macro", "examples"]
 
+[workspace.package]
+version = "2.0.0"
+
 [workspace.dependencies]
 serde_json = "1.0.140"
 tokio = { version = "1.44.2", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -69,22 +69,53 @@ parent_calls_tracked: 10
 
 ## How to use it
 
-The core concept is to remove the pain of the queue creation and reply by
-mokcing the **Nameko** architecture with a `RpcService` or `RpcClient`, and to
-use an abstract type `serde_json::Value` to manipulate a serializable data.
+The core concept is to remove the pain of queue creation and replies by
+mirroring the **Nameko** architecture with a `RpcService` or `RpcClient`, and
+to use an abstract type `serde_json::Value` to carry serializable data.
 
-if you do not use the macro `#[girolle]` you need to create a function that
-extract the data from the a `&[Value]` like this:
+Service handlers run as `async` futures and receive an [`RpcContext`] giving
+access to inbound headers and two capability handles:
+
+* `ctx.rpc.call(service, method, payload).await` — call any other service.
+* `ctx.events.dispatch(source, event_type, &payload).await` — emit a
+  Nameko-compatible event on `<source>.events`.
+
+The `#[girolle]` attribute generates a handler from a sync or async function.
+An optional first `ctx: RpcContext` argument is detected automatically.
+
+If you'd rather skip the macro you can build an [`RpcTask`] by hand from an
+[`RpcHandler`] closure:
 
 ```rust
-fn fibonacci_reccursive(s: &[Value]) -> Result<Value> {
-    let n: u64 = serde_json::from_value(s[0].clone())?;
-    let result: Value = serde_json::to_value(fibonacci(n))?;
-    Ok(result)
+use girolle::prelude::*;
+use std::sync::Arc;
+
+fn fibonacci() -> RpcTask {
+    RpcTask::new(
+        "fibonacci",
+        Arc::new(|_ctx: RpcContext, payload: Payload| -> BoxFuture<GirolleResult<Value>> {
+            Box::pin(async move {
+                let n: u64 = serde_json::from_value(payload.args()[0].clone())?;
+                Ok(serde_json::to_value(fibonacci_core(n))?)
+            })
+        }),
+    )
 }
 ```
 
-## Exemple
+## Examples
+
+The [`examples/`](./examples) crate contains runnable services and senders:
+
+| example | what it shows |
+|---|---|
+| [`simple_macro`](./examples/src/simple_macro.rs) | basic `#[girolle]` service with sync handlers |
+| [`simple_service`](./examples/src/simple_service.rs) | hand-rolled `RpcTask::new` with an async closure |
+| [`proxy_service`](./examples/src/proxy_service.rs) | `ctx.rpc.call` from inside a handler |
+| [`event_emitter`](./examples/src/event_emitter.rs) | `ctx.events.dispatch` from inside a handler |
+| [`event_observer`](./examples/src/event_observer.rs) | `RpcService::subscribe` to consume events |
+| [`cli_sender`](./examples/src/cli_sender.rs) | generic CLI sender — `<service> <method> [arg…]` |
+| [`simple_sender`](./examples/src/simple_sender.rs) | `RpcClient` round-trip with sync + async calls |
 
 ### Create a simple service
 
@@ -127,6 +158,67 @@ fn main() {
 }
 ```
 
+### Call another service from a handler
+
+```rust
+use girolle::prelude::*;
+
+#[girolle]
+async fn proxy_hello(ctx: RpcContext, name: String) -> String {
+    let result = ctx
+        .rpc
+        .call("video", "hello", Payload::new().arg(name))
+        .await
+        .expect("rpc call failed");
+    serde_json::from_value(result).expect("video.hello did not return a String")
+}
+```
+
+### Emit an event from a handler
+
+```rust
+use girolle::prelude::*;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct UserCreated { name: String }
+
+#[girolle]
+async fn create_user(ctx: RpcContext, name: String) -> String {
+    ctx.events
+        .dispatch("users", "user_created", &UserCreated { name: name.clone() })
+        .await
+        .expect("event dispatch failed");
+    format!("User {} created", name)
+}
+```
+
+### Subscribe to events
+
+```rust
+use girolle::prelude::*;
+use std::sync::Arc;
+
+fn main() {
+    let conf = Config::with_yaml_defaults("staging/config.yml".to_string()).unwrap();
+    let _ = RpcService::new(conf, "event-observer")
+        .subscribe(
+            "users",
+            "user_created",
+            Arc::new(|_ctx: RpcContext, payload: Value| -> BoxFuture<GirolleResult<()>> {
+                Box::pin(async move {
+                    println!("[users.user_created] {}", payload);
+                    Ok(())
+                })
+            }),
+        )
+        .start();
+}
+```
+
+A service can mix RPC methods (`register(...)`) and event subscriptions
+(`subscribe(...)`) freely; either one alone is also valid.
+
 ### Create multiple calls to service of methods, sync and async
 
 ```rust
@@ -168,34 +260,42 @@ Girolle use [lapin](https://github.com/amqp-rs/lapin) as an AMQP client/server l
 
 ## Supported features
 
-* [x] create a client
-  * [ ] create a proxy service in rust to interact with an other service
-* [x] Create a simple service
-  * [x] Handle the error
-  * [x] write test
-* [x] Add macro to simplify the creation of a service
-  * [x] Add basic macro
-  * [x] fix macro to handle `return`
-  * [x] fix macro to handle recursive function
-* [ ] listen to a pub/sub queue
+* [x] standalone client (sync and async)
+* [x] simple service with `#[girolle]`
+  * [x] error handling
+  * [x] tests
+* [x] macro
+  * [x] basic
+  * [x] handle `return`
+  * [x] handle recursive functions
+  * [x] support `async fn` and an optional `ctx: RpcContext` first argument
+* [x] in-service RPC client — `ctx.rpc.call(...)` from inside a handler
+* [x] event publishing — `ctx.events.dispatch(...)` (Nameko `{source}.events`)
+* [x] event subscriptions — `RpcService::subscribe(source, event_type, handler)`
+* [ ] `#[girolle_event]` macro for ergonomic subscription handlers
+* [ ] HTTP / web service entrypoint
 
 ### nameko-client
 
-The Girolle client got the basic features to send sync request and async resquest.
-I'm not really happy about the way it need to interact with. I would like to find a
-more elegant way like in the nameko. But it works, and it is not really painfull to
-use.
+The Girolle client provides sync and async sends. There's also a
+[`cli_sender`](./examples/src/cli_sender.rs) example for poking at any service
+from a terminal without hand-editing a sender file.
 
 ### nameko-rpc
 
-The RpcService and the macro procedural are the core of the lib. It does not
-suppport **proxy**, i know that's one of the most important feature of the
-**Nameko** lib. I will try to implement it in the future. But i think i need a bit refactor
-the non-oriented object aspect of Rust make it harder.
+`RpcService` plus the `#[girolle]` macro is the core. Handlers are async,
+receive an `RpcContext`, and can call other services from inside the handler
+via `ctx.rpc.call(...)` — the in-service RPC core handles the reply queue,
+correlation map, and `nameko.call_id_stack` propagation transparently.
 
 ### nameko-pubsub
 
-The PubSub service is not at all implemented. I dunno if that's something i'm interested in.
+Both sides are supported: handlers can publish events with
+`ctx.events.dispatch(source, event_type, &payload)` and services can
+subscribe to events with `RpcService::subscribe(source, event_type, handler)`.
+Exchanges follow the Nameko `{source}.events` topic convention, so a Girolle
+service can publish events that a Python Nameko service subscribes to (and
+vice versa).
 
 ### nameko-web
 

--- a/docs/content/docs/getting-started/client.md
+++ b/docs/content/docs/getting-started/client.md
@@ -16,8 +16,36 @@ top = false
 
 ## Introduction
 
-The client is a standalone client to be use with Nameko or Girolle service. It is
-made to be fast and to be able to handle a lot of request. The client is made to
-be used with the `tokio` runtime.
-The client in Girolle try to mimic the Nameko client. It is made to be easy to use
-with the sync method `send()` and the async method `call_async()` and `result()`
+The client is a standalone client to be used against Nameko or Girolle
+services. It is made to be fast and to handle a lot of requests. The client
+runs on the `tokio` runtime and tries to mimic the Nameko client. It exposes
+a sync `send()` and the async pair `call_async()` + `result()`.
+
+For a runnable end-to-end example, see
+[`examples/src/simple_sender.rs`](https://github.com/doubleailes/girolle/blob/main/examples/src/simple_sender.rs).
+
+## CLI sender for ad-hoc testing
+
+The [`examples/src/cli_sender.rs`](https://github.com/doubleailes/girolle/blob/main/examples/src/cli_sender.rs)
+example wraps `RpcClient` in a one-shot CLI that takes a service, method,
+and arguments off the command line. Useful when you want to poke at any
+service without writing a sender file:
+
+```bash
+cargo run --example cli_sender -- video hello Girolle
+cargo run --example cli_sender -- video sub 10 5
+cargo run --example cli_sender -- proxy hello Girolle
+```
+
+Each positional `arg` is parsed as JSON when possible (so numbers,
+booleans, arrays and objects work directly) and falls back to a plain
+string otherwise.
+
+## In-service RPC
+
+If you only need to call another service from inside a handler, you don't
+need an `RpcClient` at all — use `ctx.rpc.call(...)` on the `RpcContext`
+that the running `RpcService` hands to each handler. See the
+[service docs](../service/) for details and the
+[`proxy_service`](https://github.com/doubleailes/girolle/blob/main/examples/src/proxy_service.rs)
+example.

--- a/docs/content/docs/getting-started/introduction.md
+++ b/docs/content/docs/getting-started/introduction.md
@@ -29,13 +29,22 @@ Girolle use [lapin](https://github.com/amqp-rs/lapin) as an AMQP client/server l
 
 ## How to use it
 
-The core concept is to remove the pain of the queue creation and reply by
-mokcing the **Nameko** architecture, and to use an abstract type
-`serde_json::Value` to manipulate a serializable data.
+The core concept is to remove the pain of queue creation and replies by
+mirroring the **Nameko** architecture, and to use an abstract type
+`serde_json::Value` to carry serializable data.
+
+Service handlers run as async futures. Each handler is invoked with an
+`RpcContext` (inbound headers, correlation id, plus capability handles for
+calling other services and emitting events) and a `Payload` (positional
+args and kwargs). The `#[girolle]` macro hides the deserialization
+boilerplate; if you'd rather build handlers by hand you can construct an
+`RpcTask` directly from an `RpcHandler` closure.
 
 ### macro procedural
 
-The lib offer a procedural macro `#[girolle]` to create a Task like this:
+The lib offers a procedural macro `#[girolle]` to create a Task. It
+accepts both sync and async functions, and detects an optional first
+`ctx: RpcContext` argument:
 
 ```rust
 use girolle::prelude::*;
@@ -44,56 +53,63 @@ use girolle::prelude::*;
 fn hello(s: String) -> String {
     format!("Hello, {}!", s)
 }
-```
 
-The macro do a real complexe job. It transform the function into three functions:
-
-- The first function is a copy of the original function with a suffix `_core`.
-- The second one is just a wrapper to deserialize the input and serialize the output with serde_json.
-- The thrid one is the creation of the RpcTask.
-
-It returns a `fn()->RpcTask` that can be used to register to the RpcService.
-
-The macro is set to replace recursively the function call in the function body to
-call the `_core` function.
-It may result in a issue with the `#[girolle]` macro. For example:
-```rust
 #[girolle]
-fn sleep(n: u64) -> String {
-    thread::sleep(time::Duration::from_secs(n));
-    format!("Slept for {} seconds", n)
+async fn proxy_hello(ctx: RpcContext, name: String) -> String {
+    let result = ctx
+        .rpc
+        .call("video", "hello", Payload::new().arg(name))
+        .await
+        .expect("rpc call failed");
+    serde_json::from_value(result).expect("video.hello did not return a String")
 }
 ```
-The `thread::sleep` will be replace by the `thread::sleep_core` function call
-and the function will not sleep.
+
+The macro expands each annotated function into three items:
+
+- A copy of the original function with the suffix `_core`.
+- A wrapper that deserializes the inbound `Payload`, awaits `_core`, and
+  serializes the result back to a JSON `Value`.
+- A `fn() -> RpcTask` constructor used to register the handler.
+
+The macro replaces recursive calls inside the function body to call
+`_core` directly, which lets recursive functions like `fibonacci` work
+unchanged. It does this naively (textual identifier match), so an
+unrelated function with the same name as the annotated one would also be
+rewritten — for example `#[girolle] fn sleep(n: u64) { thread::sleep(...) }`
+would rewrite the `sleep` inside `thread::sleep` and break. Rename the
+handler in that case.
 
 ### hand made deserialization and serialization
 
-if you do not use the macro `#[girolle]` you need to create a function that
-extract the data from the a `&[Value]` like this and return a `Result<Value>`:
+If you'd rather skip the macro, build an `RpcTask` directly from an
+`RpcHandler` closure. The closure receives the `RpcContext` and a
+`Payload`, and returns a `BoxFuture` resolving to the JSON result:
 
 ```rust
-fn fibonacci(n: u64) -> u64 {
+use girolle::prelude::*;
+use std::sync::Arc;
+
+fn fibonacci_core(n: u64) -> u64 {
     if n <= 1 {
         return n;
     }
-    return fibonacci(n - 1) + fibonacci(n - 2);
+    fibonacci_core(n - 1) + fibonacci_core(n - 2)
 }
 
-fn fibonacci_wrap(s: &[Value]) -> Result<Value> {
-    // extract the data from the Value
-    let n: u64 = serde_json::from_value(s[0].clone())?;
-    // create the result
-    let result: Value = serde_json::to_value(fibonacci(n))?;
-    // return the result in a Result
-    Ok(result)
-}
-
-fn fibonacci_task() -> RpcTask {
-    RpcTask::new("fibonacci", vec!["n"], fibonacci)
+fn fibonacci() -> RpcTask {
+    RpcTask::new(
+        "fibonacci",
+        Arc::new(|_ctx: RpcContext, payload: Payload| -> BoxFuture<GirolleResult<Value>> {
+            Box::pin(async move {
+                let n: u64 = serde_json::from_value(payload.args()[0].clone())?;
+                Ok(serde_json::to_value(fibonacci_core(n))?)
+            })
+        }),
+    )
 }
 ```
 
-As you can see it is little bit more complexe than the macro. To create the RpcTask we need to
-set the name of the method, the list of the argument and the function that will be called. With this breabdown
-workflow you get more control to like the method register in the AMQP server.
+This form gives you direct access to `RpcContext`, full control over
+deserialization, and the ability to call other services or emit events
+from the same closure.

--- a/docs/content/docs/getting-started/quick-start.md
+++ b/docs/content/docs/getting-started/quick-start.md
@@ -123,4 +123,72 @@ def send_simple_message(name: str) -> str:
 
 For more details please check the nameko documentation about [standalone](https://nameko.readthedocs.io/en/v3.0.0-rc/api.html#module-nameko.standalone) and [rpc](https://nameko.readthedocs.io/en/v3.0.0-rc/rpc.html) services.
 
+## Use the request context
+
+Adding `ctx: RpcContext` as the first argument of a handler gives access to
+the inbound delivery's metadata and two capability handles:
+
+* `ctx.rpc.call(service, method, payload).await` — call any other service.
+* `ctx.events.dispatch(source, event_type, &payload).await` — emit a
+  Nameko-compatible event on the `<source>.events` topic exchange.
+
+```rust
+use girolle::prelude::*;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct UserCreated { name: String }
+
+#[girolle]
+async fn create_user(ctx: RpcContext, name: String) -> String {
+    ctx.events
+        .dispatch("users", "user_created", &UserCreated { name: name.clone() })
+        .await
+        .expect("event dispatch failed");
+    format!("User {} created", name)
+}
+```
+
+## Subscribe to events
+
+A service can also subscribe to events emitted by other services. Use
+`RpcService::subscribe(source, event_type, handler)`. Subscriptions can
+coexist with `register(...)` on the same service, and a service consisting
+only of subscriptions is also valid.
+
+```rust
+use girolle::prelude::*;
+use std::sync::Arc;
+
+fn main() {
+    let conf = Config::with_yaml_defaults("staging/config.yml".to_string()).unwrap();
+    let _ = RpcService::new(conf, "event-observer")
+        .subscribe(
+            "users",
+            "user_created",
+            Arc::new(|_ctx: RpcContext, payload: Value| -> BoxFuture<GirolleResult<()>> {
+                Box::pin(async move {
+                    println!("[users.user_created] {}", payload);
+                    Ok(())
+                })
+            }),
+        )
+        .start();
+}
+```
+
+## Runnable examples
+
+The `examples/` crate has a runnable example for each capability. Pick one,
+adapt it, and `cargo run --example <name>` from the repository root:
+
+| example | what it shows |
+|---|---|
+| `simple_macro` | basic `#[girolle]` service with sync handlers |
+| `simple_service` | hand-rolled `RpcTask::new` with an async closure |
+| `proxy_service` | `ctx.rpc.call` from inside a handler |
+| `event_emitter` | `ctx.events.dispatch` from inside a handler |
+| `event_observer` | `RpcService::subscribe` to consume events |
+| `cli_sender` | generic CLI sender — `<service> <method> [arg…]` |
+| `simple_sender` | `RpcClient` round-trip with sync + async calls |
 

--- a/docs/content/docs/getting-started/service.md
+++ b/docs/content/docs/getting-started/service.md
@@ -16,9 +16,61 @@ top = false
 
 ## Introduction
 
-The service is the core of the lib. It is the place where the magic happen. The
-core rely on the `lapin` lib to handle the AMQP protocol and tokio to handle the
-async and spawn part.
-Tokio spawn one delagate per vCPU to handle the request and the response. As an
-optimisation for heavy load, the lib use an async spawn to publish the response
-so if a vCPU is free, it can handle to publish the response.
+The service is the core of the lib. It is the place where the magic happens.
+The core relies on `lapin` to handle the AMQP protocol and tokio for async +
+spawn. Tokio spawns one delegate per vCPU to handle the request and the
+response. As an optimisation for heavy load, the lib uses an async spawn to
+publish the response so any free vCPU can handle the publish step.
+
+## Handler shape
+
+A service handler is registered on an `RpcService` either via the
+`#[girolle]` macro or by handing the service an `RpcTask`. Internally each
+handler is an async closure of the shape:
+
+```rust
+Arc<dyn Fn(RpcContext, Payload) -> BoxFuture<GirolleResult<Value>> + Send + Sync>
+```
+
+The handler receives the per-delivery `RpcContext` and a `Payload` carrying
+positional args and kwargs, and returns a future resolving to the JSON
+result. Errors propagate back to the caller as `GirolleError` and are
+serialized into a Nameko-compatible `RemoteError`.
+
+## RpcContext
+
+`RpcContext` carries the inbound delivery's metadata and two capability
+handles:
+
+| field | meaning |
+|---|---|
+| `service_name` | the inbound routing key's service component |
+| `method_name` | the inbound routing key's method component |
+| `correlation_id` | the AMQP correlation id of the inbound delivery |
+| `reply_to` | the requester's reply queue routing key |
+| `headers` | the raw inbound headers (incl. `nameko.call_id_stack`) |
+| `rpc` | an `RpcCaller` for outbound RPC, stamped with the inbound headers |
+| `events` | an `EventDispatcher` for emitting events, stamped with the inbound headers |
+
+Both `rpc` and `events` propagate the inbound `nameko.call_id_stack` on
+outbound messages, so distributed traces stay consistent across hops.
+
+## In-service RPC
+
+`ctx.rpc.call(service, method, payload).await` issues an outbound RPC and
+awaits the reply. Internally, the `RpcService` stands up a single shared
+reply queue, a `DashMap<correlation_id, oneshot::Sender>` correlation map,
+and a publish channel — all wired up automatically when the service starts.
+
+## Events
+
+Service handlers can publish Nameko-compatible events with
+`ctx.events.dispatch(source_service, event_type, &payload).await`. The
+`{source_service}.events` topic exchange is declared lazily on first emit
+per source, and messages are published as durable JSON.
+
+A service can also subscribe to events emitted by other services with
+`RpcService::subscribe(source_service, event_type, handler)`. The handler
+follows the same `(RpcContext, Value) -> Future` shape as RPC handlers.
+Subscriptions and `register(...)` calls can coexist on the same service;
+either alone is also valid.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -50,3 +50,11 @@ path = "src/proxy_service.rs"
 [[example]]
 name = "event_emitter"
 path = "src/event_emitter.rs"
+
+[[example]]
+name = "cli_sender"
+path = "src/cli_sender.rs"
+
+[[example]]
+name = "event_observer"
+path = "src/event_observer.rs"

--- a/examples/src/cli_sender.rs
+++ b/examples/src/cli_sender.rs
@@ -1,0 +1,55 @@
+//! Generic CLI RPC sender. Useful for poking at any service from a
+//! terminal without having to hand-edit a sender example.
+//!
+//! Usage:
+//!
+//! ```sh
+//! cargo run --example cli_sender -- <service> <method> [arg ...]
+//! ```
+//!
+//! Each `arg` is sent as a positional argument. Args are tried as JSON
+//! first (so you can pass numbers, booleans, arrays, objects); anything
+//! that doesn't parse falls back to a plain string.
+//!
+//! Examples:
+//!
+//! ```sh
+//! cargo run --example cli_sender -- video hello Girolle
+//! cargo run --example cli_sender -- video sub 10 5
+//! cargo run --example cli_sender -- proxy hello Girolle
+//! cargo run --example cli_sender -- users create_user Girolle
+//! ```
+
+use girolle::prelude::*;
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 {
+        eprintln!(
+            "usage: {} <service> <method> [arg ...]",
+            args.first().map(String::as_str).unwrap_or("cli_sender")
+        );
+        std::process::exit(2);
+    }
+    let service_name = args[1].clone();
+    let method = args[2].clone();
+    let mut payload = Payload::new();
+    for raw in &args[3..] {
+        match serde_json::from_str::<Value>(raw) {
+            Ok(v) => payload = payload.arg(v),
+            Err(_) => payload = payload.arg(raw),
+        }
+    }
+
+    let conf: Config = Config::with_yaml_defaults("staging/config.yml".to_string())?;
+    let mut rpc_client = RpcClient::new(conf);
+    rpc_client.register_service(&service_name).await?;
+    rpc_client.start().await?;
+    let result = rpc_client.send(&service_name, &method, payload)?;
+    println!("{}", result.get_value());
+    rpc_client.unregister_service(&service_name)?;
+    rpc_client.close().await?;
+    Ok(())
+}

--- a/examples/src/event_observer.rs
+++ b/examples/src/event_observer.rs
@@ -1,0 +1,36 @@
+//! Subscribes to `users.user_created` and prints incoming events.
+//!
+//! Pair this with any service that emits Nameko-compatible events on
+//! `users.events` (e.g. the `event_emitter` example, or a Python Nameko
+//! `users` service):
+//!
+//! ```sh
+//! cargo run --example event_observer
+//! ```
+//!
+//! Trigger an emit (e.g. via `cli_sender`):
+//!
+//! ```sh
+//! cargo run --example cli_sender -- users create_user Girolle
+//! ```
+//!
+//! The observer will print each event as it arrives and ack it.
+
+use girolle::prelude::*;
+use std::sync::Arc;
+
+fn main() {
+    let conf: Config = Config::with_yaml_defaults("staging/config.yml".to_string()).unwrap();
+    let _ = RpcService::new(conf, "event-observer")
+        .subscribe(
+            "users",
+            "user_created",
+            Arc::new(|_ctx: RpcContext, payload: Value| -> BoxFuture<GirolleResult<()>> {
+                Box::pin(async move {
+                    println!("[users.user_created] {}", payload);
+                    Ok(())
+                })
+            }),
+        )
+        .start();
+}

--- a/girolle/Cargo.toml
+++ b/girolle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "girolle"
-version = "1.8.5"
+version = { workspace = true }
 edition = "2021"
 authors = ["Philippe Llerena <philippe.llerena@gmail.com>"]
 description = "A nameko like lib in rust"
@@ -15,7 +15,7 @@ bench = false
 [dependencies]
 lapin = "2.5.3"
 futures = "0.3.31"
-girolle_macro = { path = "../girolle_macro", version = "1.8" }
+girolle_macro = { path = "../girolle_macro", version = "2" }
 tokio-executor-trait = "2.1.3"
 tokio-reactor-trait = "1.1.0"
 serde_yaml = "0.9.34+deprecated"

--- a/girolle/src/config.rs
+++ b/girolle/src/config.rs
@@ -309,7 +309,7 @@ impl Config {
 }
 
 // quick function to expand var in slice string
-fn expand_var(raw_config: &str) -> Cow<str> {
+fn expand_var(raw_config: &str) -> Cow<'_, str> {
     let re = Regex::new(r"\$\{([a-zA-Z_][0-9a-zA-Z_]*)\}").unwrap();
     re.replace_all(raw_config, |caps: &Captures| match env::var(&caps[1]) {
         Ok(val) => val,

--- a/girolle/src/lib.rs
+++ b/girolle/src/lib.rs
@@ -1,22 +1,27 @@
 //! ## Description
 //!
 //! This crate is a Rust implementation of the Nameko RPC protocol.
-//! It allows to create a RPC service or Rpc client in Rust that can be called
-//! from or to a Nameko microservice.
+//! It lets you build RPC services and clients in Rust that interoperate
+//! with Python [Nameko](https://github.com/nameko/nameko) services on the
+//! same broker.
 //!
-//! **Girolle** mock Nameko architecture to send request and get response,
-//! with a message-listener queue system
+//! Service handlers run as async futures. Each handler receives an
+//! [`RpcContext`] giving access to inbound headers and two capability
+//! handles:
+//!
+//! * [`RpcCaller::call`] — call any other service from inside a handler.
+//! * [`EventDispatcher::dispatch`] — emit a Nameko-compatible event on
+//!   `<source>.events`.
+//!
+//! A service can also subscribe to events emitted by other services with
+//! [`RpcService::subscribe`].
 //!
 //! ## Examples
 //!
-//! ### RPC Service
-//!
-//! This example is simple service that return a string with the name of the person.
+//! ### RPC service with the macro
 //!
 //! ```rust,no_run
-//!
 //! use girolle::prelude::*;
-//! use std::vec;
 //!
 //! #[girolle]
 //! fn hello(s: String) -> String {
@@ -24,26 +29,82 @@
 //! }
 //!
 //! fn main() {
-//!   let conf: Config = Config::with_yaml_defaults("config.yml".to_string()).unwrap();
-//!   let mut services: RpcService = RpcService::new(conf, "video");
-//!   services.register(hello).start();
+//!     let conf: Config = Config::with_yaml_defaults("config.yml".to_string()).unwrap();
+//!     let _ = RpcService::new(conf, "video").register(hello).start();
 //! }
 //! ```
 //!
-//! ### RPC Client
-//!
-//! This example is a simple client that call the hello function in the video service.
+//! ### Calling another service from a handler
 //!
 //! ```rust,no_run
 //! use girolle::prelude::*;
-//! use std::vec;
+//!
+//! #[girolle]
+//! async fn proxy_hello(ctx: RpcContext, name: String) -> String {
+//!     let result = ctx
+//!         .rpc
+//!         .call("video", "hello", Payload::new().arg(name))
+//!         .await
+//!         .expect("rpc call failed");
+//!     serde_json::from_value(result).expect("video.hello did not return a String")
+//! }
+//! ```
+//!
+//! ### Emitting an event from a handler
+//!
+//! ```rust,no_run
+//! use girolle::prelude::*;
+//! use serde::Serialize;
+//!
+//! #[derive(Serialize)]
+//! struct UserCreated { name: String }
+//!
+//! #[girolle]
+//! async fn create_user(ctx: RpcContext, name: String) -> String {
+//!     ctx.events
+//!         .dispatch("users", "user_created", &UserCreated { name: name.clone() })
+//!         .await
+//!         .expect("event dispatch failed");
+//!     format!("User {} created", name)
+//! }
+//! ```
+//!
+//! ### Subscribing to events
+//!
+//! ```rust,no_run
+//! use girolle::prelude::*;
+//! use std::sync::Arc;
+//!
+//! fn main() {
+//!     let conf = Config::with_yaml_defaults("config.yml".to_string()).unwrap();
+//!     let _ = RpcService::new(conf, "event-observer")
+//!         .subscribe(
+//!             "users",
+//!             "user_created",
+//!             Arc::new(|_ctx: RpcContext, payload: Value| -> BoxFuture<GirolleResult<()>> {
+//!                 Box::pin(async move {
+//!                     println!("[users.user_created] {}", payload);
+//!                     Ok(())
+//!                 })
+//!             }),
+//!         )
+//!         .start();
+//! }
+//! ```
+//!
+//! ### RPC client
+//!
+//! ```rust,no_run
+//! use girolle::prelude::*;
 //!
 //! #[tokio::main]
-//! async fn main() {
-//!    let mut rpc_client = RpcClient::new(Config::default());
-//!    rpc_client.register_service("video");
-//!    
-//!    let result = rpc_client.send("video", "hello", Payload::new().arg("Girolle")).unwrap();
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let mut rpc_client = RpcClient::new(Config::default());
+//!     rpc_client.register_service("video").await?;
+//!     rpc_client.start().await?;
+//!     let result = rpc_client.send("video", "hello", Payload::new().arg("Girolle"))?;
+//!     println!("{}", result.get_value());
+//!     Ok(())
 //! }
 //! ```
 mod config;

--- a/girolle/src/lib.rs
+++ b/girolle/src/lib.rs
@@ -67,4 +67,6 @@ pub use serde_json;
 pub use serde_json::{json, Value};
 mod error;
 pub use error::GirolleError;
-pub use types::{BoxFuture, EventDispatcher, GirolleResult, RpcCaller, RpcContext, RpcHandler};
+pub use types::{
+    BoxFuture, EventDispatcher, EventHandler, GirolleResult, RpcCaller, RpcContext, RpcHandler,
+};

--- a/girolle/src/prelude.rs
+++ b/girolle/src/prelude.rs
@@ -4,7 +4,9 @@ pub use crate::payload::Payload;
 pub use crate::rpc_client::{RpcClient, RpcReply, RpcResult};
 pub use crate::rpc_service::RpcService;
 pub use crate::rpc_task::RpcTask;
-pub use crate::types::{BoxFuture, EventDispatcher, GirolleResult, RpcCaller, RpcContext, RpcHandler};
+pub use crate::types::{
+    BoxFuture, EventDispatcher, EventHandler, GirolleResult, RpcCaller, RpcContext, RpcHandler,
+};
 pub use girolle_macro::girolle;
 pub use serde_json;
 pub use serde_json::{json, Value};

--- a/girolle/src/queue.rs
+++ b/girolle/src/queue.rs
@@ -2,9 +2,9 @@
 ///
 /// This module contains functions to create queues and channels for the RPC communication.
 use lapin::{
-    options::{BasicQosOptions, QueueBindOptions, QueueDeclareOptions},
+    options::{BasicQosOptions, ExchangeDeclareOptions, QueueBindOptions, QueueDeclareOptions},
     types::FieldTable,
-    Connection, ConnectionProperties,
+    Connection, ConnectionProperties, ExchangeKind,
 };
 use tracing::{error, info};
 use uuid::Uuid;
@@ -136,4 +136,66 @@ pub(crate) async fn create_message_channel(
         )
         .await?;
     Ok(response_channel)
+}
+
+/// # create_event_consumer_channel
+///
+/// Sets up a channel for consuming Nameko-style events emitted by
+/// `source_service`. The function declares the source's `{source}.events`
+/// topic exchange (idempotently — so the consumer can come up before any
+/// publisher), declares a durable consumer queue, binds it to the exchange
+/// with `event_type` as the routing key, and applies `prefetch_count`.
+///
+/// The exchange and queue declarations match the Nameko EventDispatcher
+/// publisher's conventions, so a Girolle consumer can subscribe to events
+/// emitted by a Python Nameko service and vice versa.
+pub(crate) async fn create_event_consumer_channel(
+    conn: &Connection,
+    queue_name: &str,
+    source_service: &str,
+    event_type: &str,
+    prefetch_count: u16,
+) -> lapin::Result<lapin::Channel> {
+    info!(queue = queue_name, "Create event consumer queue");
+    let channel = conn.create_channel().await?;
+    let exchange = format!("{}.events", source_service);
+
+    channel
+        .exchange_declare(
+            &exchange,
+            ExchangeKind::Topic,
+            ExchangeDeclareOptions {
+                durable: true,
+                ..Default::default()
+            },
+            FieldTable::default(),
+        )
+        .await?;
+
+    channel
+        .queue_declare(
+            queue_name,
+            QueueDeclareOptions {
+                durable: true,
+                ..Default::default()
+            },
+            FieldTable::default(),
+        )
+        .await?;
+
+    channel
+        .queue_bind(
+            queue_name,
+            &exchange,
+            event_type,
+            QueueBindOptions::default(),
+            FieldTable::default(),
+        )
+        .await?;
+
+    channel
+        .basic_qos(prefetch_count, BasicQosOptions::default())
+        .await?;
+
+    Ok(channel)
 }

--- a/girolle/src/rpc_service.rs
+++ b/girolle/src/rpc_service.rs
@@ -4,16 +4,23 @@ use crate::{
     events::EventDispatcherCore,
     nameko_utils::{compute_deliver, delivery_to_message_properties, get_id, publish},
     payload::{Payload, PayloadResult},
-    queue::{create_service_channel, get_connection},
+    queue::{create_event_consumer_channel, create_service_channel, get_connection},
     rpc_core::RpcCallerCore,
     rpc_task::RpcTask,
-    types::{EventDispatcher, RpcCaller, RpcContext},
+    types::{EventDispatcher, EventHandler, RpcCaller, RpcContext},
 };
 use lapin::{message::DeliveryResult, options::*, types::FieldTable, Channel};
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::Semaphore;
 use tracing::{debug, error, info, warn, Level};
 use uuid::Uuid;
+
+#[derive(Clone)]
+struct EventSubscription {
+    source_service: String,
+    event_type: String,
+    handler: EventHandler,
+}
 
 /// # RpcService
 ///
@@ -40,6 +47,7 @@ pub struct RpcService {
     conf: Config,
     service_name: String,
     f: HashMap<String, RpcTask>,
+    subscriptions: Vec<EventSubscription>,
 }
 impl RpcService {
     /// # new
@@ -70,6 +78,7 @@ impl RpcService {
             conf,
             service_name: service_name.to_string(),
             f: HashMap::new(),
+            subscriptions: Vec::new(),
         }
     }
     /// # set_service_name
@@ -129,6 +138,55 @@ impl RpcService {
         let routing_key = format!("{}.{}", self.service_name, method_name);
         self.f.insert(routing_key.to_string(), f);
     }
+    /// # subscribe
+    ///
+    /// Register an async event handler for `<source_service>.events` with
+    /// routing key `event_type`.
+    ///
+    /// Multiple `subscribe` calls can coexist with `register` calls on the
+    /// same service. A service consisting only of subscriptions (no RPC
+    /// methods) is allowed.
+    ///
+    /// ## Arguments
+    ///
+    /// * `source_service` — the name of the service emitting the event
+    /// * `event_type` — the event's routing key (typically a verb like
+    ///   `user_created`)
+    /// * `handler` — an [`EventHandler`] invoked with [`RpcContext`] and the
+    ///   decoded JSON payload
+    ///
+    /// ## Example
+    ///
+    /// ```rust,no_run
+    /// use girolle::prelude::*;
+    /// use std::sync::Arc;
+    ///
+    /// fn main() {
+    ///     let _ = RpcService::new(Config::default(), "observer").subscribe(
+    ///         "users",
+    ///         "user_created",
+    ///         Arc::new(|_ctx, payload| {
+    ///             Box::pin(async move {
+    ///                 println!("event: {}", payload);
+    ///                 Ok(())
+    ///             })
+    ///         }),
+    ///     );
+    /// }
+    /// ```
+    pub fn subscribe(
+        mut self,
+        source_service: &str,
+        event_type: &str,
+        handler: EventHandler,
+    ) -> Self {
+        self.subscriptions.push(EventSubscription {
+            source_service: source_service.to_string(),
+            event_type: event_type.to_string(),
+            handler,
+        });
+        self
+    }
     /// # start
     ///
     /// ## Description
@@ -150,11 +208,16 @@ impl RpcService {
     ///    services.register(hello).start();
     /// }
     pub fn start(&self) -> Result<(), GirolleError> {
-        if self.f.is_empty() {
-            panic!("No function insert");
+        if self.f.is_empty() && self.subscriptions.is_empty() {
+            panic!("RpcService has neither RPC methods nor event subscriptions");
         }
-        // Need to clone f because it is behind a shared reference
-        rpc_service(&self.conf, &self.service_name, self.f.clone())
+        // Need to clone because the field is behind a shared reference.
+        rpc_service(
+            &self.conf,
+            &self.service_name,
+            self.f.clone(),
+            self.subscriptions.clone(),
+        )
     }
     /// # get_routing_keys
     ///
@@ -230,7 +293,7 @@ struct SharedData {
     f_task: HashMap<String, RpcTask>,
     rpc_exchange: String,
     service_name: String,
-    semaphore: Semaphore,
+    semaphore: Arc<Semaphore>,
     parent_calls_tracked: usize,
     rpc_caller: RpcCaller,
     event_dispatcher: EventDispatcher,
@@ -252,6 +315,7 @@ async fn rpc_service(
     conf: &Config,
     service_name: &str,
     f_task: HashMap<String, RpcTask>,
+    subscriptions: Vec<EventSubscription>,
 ) -> Result<(), GirolleError> {
     info!("Starting the service");
     // Define the queue name1
@@ -264,6 +328,13 @@ async fn rpc_service(
     let id = Uuid::new_v4();
     // check list of function
     debug!("List of functions {:?}", f_task.keys());
+    debug!(
+        "List of subscriptions {:?}",
+        subscriptions
+            .iter()
+            .map(|s| format!("{}.events/{}", s.source_service, s.event_type))
+            .collect::<Vec<_>>()
+    );
     let conn = get_connection(conf.AMQP_URI(), conf.heartbeat()).await?;
     // Create a channel for the service in Nameko this part is handle by
     // the RpcConsumer class
@@ -280,6 +351,91 @@ async fn rpc_service(
     // Stand up the event-dispatcher core: a publish channel and a cache
     // of declared `{source}.events` exchanges used by ctx.events.dispatch().
     let event_dispatcher_core = EventDispatcherCore::new(&conn, conf, id).await?;
+    let rpc_caller = RpcCaller::from_core(rpc_caller_core);
+    let event_dispatcher = EventDispatcher::from_core(event_dispatcher_core);
+    let semaphore = Arc::new(Semaphore::new(conf.max_workers() as usize));
+
+    // Spin up a consumer per event subscription, reusing the shared
+    // semaphore and capabilities. Each subscription gets its own queue,
+    // bound to `<source>.events` with routing key `<event_type>`.
+    for sub in &subscriptions {
+        let queue_name = format!(
+            "evt-{}-{}--{}",
+            sub.source_service, sub.event_type, service_name
+        );
+        let event_channel = create_event_consumer_channel(
+            &conn,
+            &queue_name,
+            &sub.source_service,
+            &sub.event_type,
+            conf.prefetch_count(),
+        )
+        .await?;
+        let consumer = event_channel
+            .basic_consume(
+                &queue_name,
+                "girolle_event_consumer",
+                BasicConsumeOptions::default(),
+                FieldTable::default(),
+            )
+            .await?;
+        let handler = sub.handler.clone();
+        let semaphore = Arc::clone(&semaphore);
+        let rpc_caller = rpc_caller.clone();
+        let event_dispatcher = event_dispatcher.clone();
+        let service_name_owned = service_name.to_string();
+        let event_type_owned = sub.event_type.clone();
+        consumer.set_delegate(move |delivery: DeliveryResult| {
+            let handler = handler.clone();
+            let semaphore = Arc::clone(&semaphore);
+            let rpc_caller = rpc_caller.clone();
+            let event_dispatcher = event_dispatcher.clone();
+            let service_name_owned = service_name_owned.clone();
+            let event_type_owned = event_type_owned.clone();
+            async move {
+                let _permit = semaphore.acquire().await;
+                let delivery = match delivery {
+                    Ok(Some(delivery)) => delivery,
+                    Ok(None) => return,
+                    Err(error) => {
+                        error!("Failed to consume event message {}", error);
+                        return;
+                    }
+                };
+                let payload: serde_json::Value = match serde_json::from_slice(&delivery.data) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        error!(error = %e, "event payload was not valid JSON; dropping");
+                        let _ = delivery
+                            .ack(BasicAckOptions::default())
+                            .await;
+                        return;
+                    }
+                };
+                let inbound_headers = delivery
+                    .properties
+                    .headers()
+                    .clone()
+                    .unwrap_or_default();
+                let rpc = rpc_caller.with_parent_headers(inbound_headers.clone());
+                let events = event_dispatcher.with_parent_headers(inbound_headers.clone());
+                let ctx = RpcContext {
+                    service_name: service_name_owned,
+                    method_name: event_type_owned,
+                    correlation_id: String::new(),
+                    reply_to: String::new(),
+                    headers: inbound_headers,
+                    rpc,
+                    events,
+                };
+                if let Err(e) = handler(ctx, payload).await {
+                    error!(error = %e, "event handler failed; acking and continuing");
+                }
+                let _ = delivery.ack(BasicAckOptions::default()).await;
+            }
+        });
+    }
+
     // Start a consumer.
     let consumer = rpc_channel
         .basic_consume(
@@ -294,10 +450,10 @@ async fn rpc_service(
         f_task,
         rpc_exchange: conf.rpc_exchange().to_string(),
         service_name: service_name.to_string(),
-        semaphore: Semaphore::new(conf.max_workers() as usize),
+        semaphore,
         parent_calls_tracked: conf.parent_calls_tracked() as usize,
-        rpc_caller: RpcCaller::from_core(rpc_caller_core),
-        event_dispatcher: EventDispatcher::from_core(event_dispatcher_core),
+        rpc_caller,
+        event_dispatcher,
     });
     consumer.set_delegate(move |delivery: DeliveryResult| {
         let shared_data = Arc::clone(&shared_data);

--- a/girolle/src/types.rs
+++ b/girolle/src/types.rs
@@ -171,3 +171,14 @@ pub struct RpcContext {
 /// [`Payload`] and returns a future resolving to the handler's JSON result.
 pub type RpcHandler =
     Arc<dyn Fn(RpcContext, Payload) -> BoxFuture<GirolleResult<Value>> + Send + Sync>;
+
+/// # EventHandler
+///
+/// Async handler signature for an event subscription registered via
+/// [`RpcService::subscribe`](crate::RpcService::subscribe).
+///
+/// The handler receives the per-event [`RpcContext`] and the decoded JSON
+/// payload, and returns a future resolving to `Ok(())` on success. Errors
+/// are logged but do not nack the message — events are best-effort.
+pub type EventHandler =
+    Arc<dyn Fn(RpcContext, Value) -> BoxFuture<GirolleResult<()>> + Send + Sync>;

--- a/girolle_macro/Cargo.toml
+++ b/girolle_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "girolle_macro"
-version = "1.8.5"
+version = { workspace = true }
 edition = "2021"
 readme = "../README.md"
 license-file = "../LICENSE"

--- a/nameko-examples/nameko_user_audit.py
+++ b/nameko-examples/nameko_user_audit.py
@@ -1,0 +1,29 @@
+"""
+Minimal Python Nameko mirror of `examples/src/event_observer.rs`.
+
+Subscribes to `users.events / user_created` and prints each event as it
+arrives. Use it to verify Rust-emitter → Python-subscriber wire
+compatibility against the Rust `event_emitter` example.
+
+Run from this directory:
+
+    RABBITMQ_USER=... \
+    RABBITMQ_PASSWORD=... \
+    RABBITMQ_HOST=... \
+    uv run nameko run --config ../staging/config.yml nameko_user_audit
+
+Then trigger an emit (Rust side):
+
+    cargo run --example event_emitter        # in another terminal
+    cargo run --example cli_sender -- users create_user Girolle
+"""
+
+from nameko.events import event_handler
+
+
+class UserAuditService:
+    name = "user_audit"
+
+    @event_handler("users", "user_created")
+    def on_user_created(self, payload):
+        print("[users.user_created] {}".format(payload))

--- a/nameko-examples/nameko_users.py
+++ b/nameko-examples/nameko_users.py
@@ -1,0 +1,31 @@
+"""
+Minimal Python Nameko mirror of `examples/src/event_emitter.rs`.
+
+Exposes `users.create_user(name)` and emits a `user_created` event on the
+`users.events` topic exchange. Use it to verify cross-language wire
+compatibility with the Rust `event_observer` example.
+
+Run from this directory:
+
+    RABBITMQ_USER=... \
+    RABBITMQ_PASSWORD=... \
+    RABBITMQ_HOST=... \
+    nameko run --config config.yml nameko_users
+
+Then trigger from the project root:
+
+    cargo run --example cli_sender -- users create_user Girolle
+"""
+
+from nameko.events import EventDispatcher
+from nameko.rpc import rpc
+
+
+class UsersService:
+    name = "users"
+    dispatch = EventDispatcher()
+
+    @rpc
+    def create_user(self, name):
+        self.dispatch("user_created", {"name": name})
+        return "User {} created".format(name)


### PR DESCRIPTION
## Summary
Tooling + lib changes that make the new RPC and events features testable locally without the RabbitMQ management UI.

### Library
- New `EventHandler` type alias mirroring `RpcHandler`: \`Arc<dyn Fn(RpcContext, Value) -> BoxFuture<GirolleResult<()>> + Send + Sync>\`.
- \`RpcService::subscribe(source_service, event_type, handler)\` registers an async event handler. A service may now consist of RPC methods, event subscriptions, or both. The empty-service panic now triggers only when both are empty.
- New \`queue::create_event_consumer_channel\` declares the source's \`{source}.events\` topic exchange (idempotent, durable), declares a durable consumer queue \`evt-<source>-<event_type>--<service>\`, binds with the routing key, and applies \`prefetch_count\`. The consumer can come up before any publisher.
- \`rpc_service\` startup spins up one consumer per subscription. Each delivery is decoded as JSON, wrapped in an \`RpcContext\` (with the inbound headers stamped on the \`RpcCaller\`), and handed to the handler. Acks always fire, even if the handler errors — events are best-effort.
- The shared \`Semaphore\` is now \`Arc<Semaphore>\` so RPC and event consumers share the same \`max_workers\` budget.

### Examples
- \`cli_sender\` — generic CLI RPC sender:
    \`cargo run --example cli_sender -- <service> <method> [arg ...]\`
  Args are parsed as JSON when possible, falling back to plain strings, so numbers / booleans / objects can be passed directly.
- \`event_observer\` — subscribes to \`users.user_created\` and prints each event as it arrives.

## Relationship to other PRs
- Independent of #157 (event dispatcher). Code-wise the consumer doesn't import the dispatcher, but to test events end-to-end you'll want both #157 and this PR merged. Either order works.

## Local test plan
1. \`cargo run --example simple_macro\`
2. \`cargo run --example proxy_service\`
3. \`cargo run --example cli_sender -- proxy hello Girolle\` → expect \`\"Hello, Girolle!\"\`.
4. (After #157) \`cargo run --example event_emitter\` and \`cargo run --example event_observer\` in two terminals.
5. \`cargo run --example cli_sender -- users create_user Girolle\`
6. The observer prints \`[users.user_created] {\"name\":\"Girolle\"}\`.

## Checks
- [x] \`cargo build --workspace --examples\`
- [x] \`cargo test --workspace --lib\` (14 passed)
- [x] \`cargo test --workspace --doc\` (31 + 1 passed — one new doctest for \`subscribe\`)
- [x] \`cargo clippy --workspace --all-targets\`

## Known limitations (deferred)
- No \`#[girolle_event]\` macro yet; subscribers construct an \`Arc\` closure manually. Same shape as the hand-rolled \`RpcTask::new\` form, so consistent with the rest of the API.
- One handler per \`(source, event_type)\` per service. Multiple handlers would need queue-name disambiguation; not hard, can follow up if needed.
- Event handler errors are logged but don't nack — best-effort delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)